### PR TITLE
Current Ada runtime implementation used in Genode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,30 @@
+# generic Ada runtime implementation
+
+## directory structure
+
+ - `src/`: ada runtime sources
+ - `src/lib`: implementations of required functionality, e.g. a range allocator for the secondary stack
+
+## required environment
+
+### missing runtime symbols
+
+These symbols should be provided by the runtime itself, later they should not be missing.
+
+ - `__gnat_personality_v0`
+ - `__gnat_rcheck_CE_Explicit_Raise`
+ - `__gnat_rcheck_CE_Index_Check`
+ - `__gnat_rcheck_CE_Overflow_Check`
+ - `__gnat_rcheck_PE_Explicit_Raise`
+ - `__gnat_rcheck_SE_Explicit_Raise`
+
+### external symbols
+
+The following symbols are required to be provided by the platform. They are platform dependent and should not be implemented here:
+
+ - `raise_ada_exception` is a `void func(char *name, char *message)` that gets the exceptions name and message (may be null pointers with the current implementation) and propagates them
+ - `warn_unimplemented_function` is a `void func(char *message)` warning message that is called in not or incompletely implemented functions
+ - `__gnat_malloc` is a `void *func(size_t size)` allocator that returns a pointer to a allocated chunk of memory of size `size`
+ - `__gnat_free` is a `void func(void *ptr)` that frees the memory allocated by `__gnat_malloc`
+ - `allocate_secondary_stack` is a `void *func(void *thread, size_t size)` that allocates a secondary stack of size `size` for thread `thread` (which can be either a pointer to a stack object or a stack identifier)
+ - `get_thread` is a `void *func()` that returns the current thread (should be consistent to the implementation of `thread` in `allocate_secondary_stack`)

--- a/src/a-except.adb
+++ b/src/a-except.adb
@@ -1,0 +1,70 @@
+package body Ada.Exceptions is
+
+   ----------------------------
+   -- Raise_Exception_Always --
+   ----------------------------
+
+   procedure Raise_Exception_Always (
+                                     E       : Exception_Id;
+                                     Message : String := ""
+                                    )
+   is
+      procedure Raise_Ada_Exception (
+                                     Name : System.Address;
+                                     Msg  : System.Address
+                                    )
+        with
+          Import,
+          Convention => C,
+          External_Name => "raise_ada_exception";
+      C_Msg : String := Message & Character'Val (0);
+   begin
+      Warn_Not_Implemented ("Raise_Exception_Always");
+      Raise_Ada_Exception (E.Full_Name, C_Msg'Address);
+   end Raise_Exception_Always;
+
+   procedure Raise_Exception (
+                              E       : Exception_Id;
+                              Message : String := ""
+                             )
+   is
+   begin
+      Raise_Exception_Always (E, Message);
+   end Raise_Exception;
+
+   procedure Reraise_Occurrence_No_Defer (
+                                          X : Exception_Occurrence
+                                         )
+   is
+      pragma Unreferenced (X);
+   begin
+      Warn_Not_Implemented ("Reraise_Occurrence_No_Defer");
+   end Reraise_Occurrence_No_Defer;
+
+   procedure Save_Occurrence (
+                              Target : out Exception_Occurrence;
+                              Source : Exception_Occurrence
+                             )
+   is
+   begin
+      Warn_Not_Implemented ("Save_Occurrence");
+      Target := Source;
+   end Save_Occurrence;
+
+   procedure Warn_Not_Implemented (
+                                   Name : String
+                                  )
+   is
+      procedure C_Warn_Unimplemented_Function (
+                                               Func : System.Address
+                                              )
+        with
+          Import,
+          Convention => C,
+          External_Name => "warn_unimplemented_function";
+      C_Name : String := Name & Character'Val (0);
+   begin
+      C_Warn_Unimplemented_Function (C_Name'Address);
+   end Warn_Not_Implemented;
+
+end Ada.Exceptions;

--- a/src/a-except.ads
+++ b/src/a-except.ads
@@ -1,0 +1,60 @@
+with System;
+
+package Ada.Exceptions is
+
+   type Exception_Id is private;
+   type Exception_Occurrence is limited private;
+   type Exception_Occurrence_Access is access all Exception_Occurrence;
+
+   procedure Raise_Exception_Always (
+                                     E : Exception_Id;
+                                     Message : String := ""
+                                    )
+     with
+       Export,
+       Convention => Ada,
+       External_Name => "__gnat_raise_exception";
+
+   procedure Raise_Exception (
+                              E : Exception_Id;
+                              Message : String := ""
+                             );
+
+   procedure Reraise_Occurrence_No_Defer (
+                                          X : Exception_Occurrence
+                                         );
+
+   procedure Save_Occurrence (
+                              Target : out Exception_Occurrence;
+                              Source : Exception_Occurrence
+                             );
+
+private
+
+   --  the following declarations belong to s-stalib.ads
+   --  begin s-stalib.ads
+   type Exception_Data;
+   type Exception_Data_Ptr is access all Exception_Data;
+   type Raise_Action is access procedure;
+
+   type Exception_Data is record
+      Not_Handled_By_Others : Boolean;
+      Lang                  : Character;
+      Name_Length           : Natural;
+      Full_Name             : System.Address;
+      HTable_Ptr            : Exception_Data_Ptr;
+      Foreign_Data          : System.Address;
+      Raise_Hook            : Raise_Action;
+   end record;
+   --  end s-stalib.ads
+
+   type Exception_Id is new Exception_Data_Ptr;
+   type Exception_Occurrence is record
+      null;
+   end record;
+
+   procedure Warn_Not_Implemented (
+                                   Name : String
+                                  );
+
+end Ada.Exceptions;

--- a/src/lib/ss_utils.adb
+++ b/src/lib/ss_utils.adb
@@ -1,0 +1,158 @@
+package body Ss_Utils
+  with SPARK_Mode
+is
+
+   procedure Get_Mark (
+                       T               : Thread;
+                       Thread_Registry : in out Registry;
+                       E               : out Mark
+                      )
+   is
+      Thread_Entry     : Long_Integer := -1;
+      First_Free_Entry : Long_Integer := -1;
+   begin
+      Search :
+      for E in Thread_Registry'Range loop
+         pragma Loop_Invariant (First_Free_Entry < 128);
+         pragma Loop_Invariant (Thread_Entry < 128);
+         if First_Free_Entry = -1 and then
+           Thread_Registry (E).Id = Invalid_Thread
+         then
+            First_Free_Entry := E;
+         end if;
+
+         if T = Thread_Registry (E).Id then
+            Thread_Entry := E;
+            exit Search;
+         end if;
+      end loop Search;
+
+      if Thread_Entry < 0 then
+         if First_Free_Entry >= 0 then
+            Thread_Registry (First_Free_Entry).Id := T;
+            Thread_Registry (First_Free_Entry).Data :=
+              (Base  => System.Null_Address,
+               Top   => 0);
+            Thread_Entry := First_Free_Entry;
+         else
+            raise Constraint_Error;
+         end if;
+      end if;
+
+      if Thread_Registry (Thread_Entry).Data.Base = System.Null_Address then
+         Thread_Registry (Thread_Entry).Data :=
+           (Base  => Allocate_Stack (T, Secondary_Stack_Size),
+            Top   => 0);
+      end if;
+
+      E := Thread_Registry (Thread_Entry).Data;
+   end Get_Mark;
+
+   procedure Set_Mark (
+                       T               : Thread;
+                       M               : Mark;
+                       Thread_Registry : in out Registry
+                      )
+   is
+      Thread_Entry : Long_Integer := -1;
+   begin
+      if T = Invalid_Thread then
+         raise Constraint_Error;
+      end if;
+      if M.Base = System.Null_Address then
+         raise Constraint_Error;
+      end if;
+
+      Search :
+      for E in Thread_Registry'Range loop
+         pragma Loop_Invariant (Thread_Entry < 128);
+         if T = Thread_Registry (E).Id then
+            Thread_Entry := E;
+            exit Search;
+         end if;
+      end loop Search;
+
+      if Thread_Entry < 0 then
+         raise Constraint_Error;
+      end if;
+
+      Thread_Registry (Thread_Entry).Data := M;
+   end Set_Mark;
+
+   function Allocate_Stack (
+                            T    : Thread;
+                            Size : SSE.Storage_Count
+                           ) return System.Address
+   is
+      Stack : System.Address;
+   begin
+      if T = Invalid_Thread then
+         raise Constraint_Error;
+      end if;
+      Stack := C_Alloc (T, Size);
+      if Stack = System.Null_Address then
+         raise Storage_Error;
+      end if;
+      return Stack;
+   end Allocate_Stack;
+
+   procedure S_Allocate (
+                         Address      : out System.Address;
+                         Storage_Size : SSE.Storage_Count;
+                         Reg          : in out Registry;
+                         T            : Thread
+                        )
+   is
+      M         : Mark;
+   begin
+      Get_Mark (T, Reg, M);
+      if M.Top < Secondary_Stack_Size and then
+        Storage_Size < Secondary_Stack_Size and then
+        Storage_Size + M.Top < Secondary_Stack_Size
+      then
+         M.Top := M.Top + Storage_Size;
+         Address := M.Base - M.Top;
+      else
+         raise Storage_Error;
+      end if;
+
+      Set_Mark (T, M, Reg);
+   end S_Allocate;
+
+   procedure S_Mark (
+                     Stack_Base : out System.Address;
+                     Stack_Ptr  : out SSE.Storage_Count;
+                     Reg        : in out Registry;
+                     T          : Thread
+                    )
+   is
+      M : Mark;
+   begin
+      Get_Mark (T, Reg, M);
+
+      Stack_Base := M.Base;
+      Stack_Ptr := M.Top;
+   end S_Mark;
+
+   procedure S_Release (
+                        Stack_Base : System.Address;
+                        Stack_Ptr  : SSE.Storage_Count;
+                        Reg        : in out Registry;
+                        T          : Thread
+                       )
+   is
+      LM : Mark;
+   begin
+      Get_Mark (T, Reg, LM);
+
+      if Stack_Ptr > LM.Top or Stack_Base /= LM.Base
+      then
+         raise Program_Error;
+      end if;
+
+      LM.Top := Stack_Ptr;
+
+      Set_Mark (T, LM, Reg);
+   end S_Release;
+
+end Ss_Utils;

--- a/src/lib/ss_utils.ads
+++ b/src/lib/ss_utils.ads
@@ -1,0 +1,107 @@
+with System;
+with System.Storage_Elements;
+use all type System.Address;
+use all type System.Storage_Elements.Storage_Offset;
+
+package Ss_Utils
+  with SPARK_Mode
+is
+
+   package SSE renames System.Storage_Elements;
+
+   type Thread is new System.Address;
+   Invalid_Thread : constant Thread := Thread (System.Null_Address);
+
+   type Mark is
+      record
+         Base  : System.Address;
+         Top   : SSE.Storage_Count;
+      end record;
+
+   type Registry_Entry is
+      record
+         Id    : Thread;
+         Data  : Mark;
+      end record;
+
+   type Registry is array (Long_Integer range 0 .. 127) of Registry_Entry;
+
+   Null_Registry : constant Registry := (others =>
+                                    (Id   => Invalid_Thread,
+                                     Data => (Base  => System.Null_Address,
+                                              Top   => 0)));
+
+   Secondary_Stack_Size : constant SSE.Storage_Count := 768 * 1024;
+
+   procedure Get_Mark (
+                       T               : Thread;
+                       Thread_Registry : in out Registry;
+                       E               : out Mark
+                      )
+     with
+       Pre => T /= Invalid_Thread,
+       Post => (E.Base /= System.Null_Address);
+
+   procedure Set_Mark (
+                       T               : Thread;
+                       M               : Mark;
+                       Thread_Registry : in out Registry
+                      )
+     with
+       Pre => (M.Base /= System.Null_Address and
+                 T /= Invalid_Thread);
+
+   function Allocate_Stack (
+                            T    : Thread;
+                            Size : SSE.Storage_Count
+                           ) return System.Address
+     with
+       Pre => T /= Invalid_Thread,
+       Post => Allocate_Stack'Result /= System.Null_Address;
+
+   procedure S_Allocate (
+                         Address      : out System.Address;
+                         Storage_Size : SSE.Storage_Count;
+                         Reg          : in out Registry;
+                         T            : Thread
+                        )
+     with
+       Pre => T /= Invalid_Thread;
+
+   procedure S_Mark (
+                     Stack_Base : out System.Address;
+                     Stack_Ptr  : out SSE.Storage_Count;
+                     Reg        : in out Registry;
+                     T          : Thread
+                    )
+     with
+       Pre => T /= Invalid_Thread;
+
+   procedure S_Release (
+                        Stack_Base : System.Address;
+                        Stack_Ptr  : SSE.Storage_Count;
+                        Reg        : in out Registry;
+                        T          : Thread
+                       )
+     with
+       Pre => T /= Invalid_Thread;
+
+   function C_Alloc (
+                     T    : Thread;
+                     Size : SSE.Storage_Count
+                    ) return System.Address
+     with
+       Import,
+       Convention => C,
+       External_Name => "allocate_secondary_stack",
+       Pre => T /= Invalid_Thread,
+       Post => C_Alloc'Result /= System.Null_Address,
+       Global => null;
+
+   function C_Get_Thread return Thread
+     with
+       Import,
+       Convention => C,
+       External_Name => "get_thread";
+
+end Ss_Utils;

--- a/src/s-secsta.adb
+++ b/src/s-secsta.adb
@@ -1,0 +1,52 @@
+package body System.Secondary_Stack is
+
+   procedure SS_Allocate (
+                          Address      : out System.Address;
+                          Storage_Size : SSE.Storage_Count
+                         )
+   is
+      T : constant Ss_Utils.Thread := Ss_Utils.C_Get_Thread;
+   begin
+      if T /= Ss_Utils.Invalid_Thread then
+         Ss_Utils.S_Allocate (Address,
+                              Storage_Size,
+                              Thread_Registry,
+                              T);
+      else
+         raise Program_Error;
+      end if;
+   end SS_Allocate;
+
+   function SS_Mark return Mark_Id
+   is
+      M : Mark_Id;
+      T : constant Ss_Utils.Thread := Ss_Utils.C_Get_Thread;
+   begin
+      if T /= Ss_Utils.Invalid_Thread then
+         Ss_Utils.S_Mark (M.Sstk,
+                          SSE.Storage_Count (M.Sptr),
+                          Thread_Registry,
+                          T);
+      else
+         raise Program_Error;
+      end if;
+      return M;
+   end SS_Mark;
+
+   procedure SS_Release (
+                         M : Mark_Id
+                        )
+   is
+      T : constant Ss_Utils.Thread := Ss_Utils.C_Get_Thread;
+   begin
+      if T /= Ss_Utils.Invalid_Thread then
+         Ss_Utils.S_Release (M.Sstk,
+                             SSE.Storage_Count (M.Sptr),
+                             Thread_Registry,
+                             T);
+      else
+         raise Program_Error;
+      end if;
+   end SS_Release;
+
+end System.Secondary_Stack;

--- a/src/s-secsta.ads
+++ b/src/s-secsta.ads
@@ -1,0 +1,33 @@
+with System.Storage_Elements;
+with Ss_Utils;
+use all type Ss_Utils.Thread;
+
+package System.Secondary_Stack is
+
+   package SSE renames System.Storage_Elements;
+
+   type Mark_Id is private;
+
+   procedure SS_Allocate (
+                          Address      : out System.Address;
+                          Storage_Size : SSE.Storage_Count
+                         );
+
+   function SS_Mark return Mark_Id;
+
+   procedure SS_Release (
+                         M : Mark_Id
+                        );
+
+private
+
+   SS_Pool : Integer;
+
+   type Mark_Id is record
+      Sstk : System.Address;
+      Sptr : SSE.Integer_Address;
+   end record;
+
+   Thread_Registry : Ss_Utils.Registry := Ss_Utils.Null_Registry;
+
+end System.Secondary_Stack;


### PR DESCRIPTION
I added the Ada code of the current runtime we use in Genode. Please take a look if the description of the symbols is sufficient. Also I forgot that the exceptions (`__gnat_rcheck_XX_*`) were implemented in Genode in C++ so they also need to be implemented somewhere but I'm unsure what the right place is yet. I'm also unsure where `__gnat_personality_v0` comes from, it was undefined when I built the files in this repository manually.
The external symbols are what should be implemented by the specific platform.