### PR TITLE
Support text output through GNAT.IO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERBOSE ?= @
+
 COMPONENT = rts
 OBJ_DIR = obj
 TEST_DIR = tests/system
@@ -35,40 +37,40 @@ dummy := $(shell mkdir -p $(OBJ_DIR)/adainclude $(OBJ_DIR)/adalib $(OBJ_DIR)/lib
 runtime: $(OBJ_DIR)/adalib/libgnat.a
 
 $(OBJ_DIR)/adalib/libgnat.a: $(addprefix $(OBJ_DIR)/adainclude/,$(SRC))
-	gprbuild --RTS=./obj -P$(COMPONENT) -p
+	$(VERBOSE)gprbuild --RTS=./obj -P$(COMPONENT) -p
 
 $(OBJ_DIR)/adainclude/%: src/%
-	cp -a $< $@
+	$(VERBOSE)cp -a $< $@
 
 $(OBJ_DIR)/adainclude/%: src/lib/%
-	cp -a $< $@
+	$(VERBOSE)cp -a $< $@
 
 $(OBJ_DIR)/adainclude/%: contrib/gcc-6.3.0/%
-	cp -v -a $< $@
+	$(VERBOSE)cp -a $< $@
 
 platform: $(OBJ_DIR)/lib/libposix_rts.a
 
 $(OBJ_DIR)/lib/libposix_rts.a: $(OBJ_DIR)/posix.o
-	ar rcs $@ $^
+	$(VERBOSE)ar rcs $@ $^
 
 $(OBJ_DIR)/%.o: platform/%.c
-	gcc -c -o $@ $<
+	$(VERBOSE)gcc -c -o $@ $<
 
 clean: clean_test
-	@rm -rf $(OBJ_DIR)
+	$(VERBOSE)rm -rf $(OBJ_DIR)
 
 TEST_DIRS = $(addprefix $(TEST_DIR)/,$(shell ls tests/system))
 TEST_BINS = $(addsuffix /test,$(TEST_DIRS))
 
 $(TEST_DIR)/%/test:
 	@echo "TEST $(dir $@)"
-	@cd $(dir $@) && gprbuild --RTS=../../../obj -p && ./test
+	$(VERBOSE)cd $(dir $@) && gprbuild -q --RTS=../../../obj -p && ./test
 
 $(UNIT_DIR)/test:
 	@echo "UNITTEST $(dir $@)"
-	@cd $(dir $@) && gprbuild -P test && ./test
+	$(VERBOSE)cd $(dir $@) && gprbuild -q -P test && ./test
 
 test: runtime platform clean_test $(TEST_BINS) $(UNIT_DIR)/test
 
 clean_test:
-	$(foreach DIR,$(TEST_DIRS) $(UNIT_DIR),cd $(DIR) && gprclean -Ptest -r; cd -;)
+	$(VERBOSE)$(foreach DIR,$(TEST_DIRS) $(UNIT_DIR),cd $(DIR) && gprclean -q -Ptest -r; cd -;)

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,10 @@ SRC = a-except.adb \
       exit.c \
       init.c
 
+ifneq ($(USE_GNATIO),)
+SRC += gnat.ads g-io.ads g-io.adb
+endif
+
 SRC := $(sort $(SRC) $(patsubst %.adb, %.ads, $(filter %.adb, $(SRC))))
 
 dummy := $(shell mkdir -p $(OBJ_DIR)/adainclude $(OBJ_DIR)/adalib $(OBJ_DIR)/lib)

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ A downsized Ada runtime which can be adapted to different platforms.
 
 ## Platform-specific Symbols
 
-Some symbols are required to be provided by the platform. Please have a look into the [platform interface](https://github.com/Componolit/ada-runtime/wiki/Platform-interface) description.
+Some symbols are required to be provided by the platform. Please have a look into the [platform interface](doc/Platform-interface.md) description.

--- a/doc/Platform-interface.md
+++ b/doc/Platform-interface.md
@@ -1,0 +1,177 @@
+| Symbol                       | C signature                                            | Ada signature                                                                                      |
+|------------------------------|--------------------------------------------------------|----------------------------------------------------------------------------------------------------|
+| `log_debug`                  | `void log_debug(char *)`                               | `procedure Log_Debug(Msg : String)`                                                                |
+| `log_warning`                | `void log_warning(char *)`                             | `procedure Log_Warning(Msg : String)`                                                              |
+| `log_error`                  | `void log_error(char *)`                               | `procedure Log_Error(Msg : String)`                                                                |
+| `__gnat_malloc`              | `void *__gnat_malloc(size_t)`                          | `function Malloc(Size : Natural) return System.Address`                                            |
+| `__gnat_free`                | `void __gnat_free(void *)`                             | `procedure Free(Ptr : System.Address)`                                                             |
+| `__gnat_unhandled_terminate` | `void __gnat_unhandled_terminate()`                    | `procedure Unhandled_Terminate`                                                                    |
+| `allocate_secondary_stack`   | `void *allocate_secondary_stack(void *, size_t)`       | `function Allocate_Secondary_Stack(Thread : System.Address; Size : Natural) return System.Address` |
+| `get_thread`                 | `void *get_thread()`                                   | `function Get_Thread return System.Address`                                                        |
+| `raise_ada_exception`        | `void raise_ada_exception(exception_t, char *, char*)` | `procedure Raise_Ada_Exception(T : Exception_Type; Name : String; Msg : String)`                                       |
+| `put_char`                   | `void put_char(const char)`                            | `procedure Put_Char(C : Character)`                                                                                    |
+| `put_char_stderr`            | `void put_char_stderr(const char)`                     | `procedure Put_Char_Stderr(C : Character)`                                                                             |
+| `put_int`                    | `void put_int(const int)`                              | `procedure Put_Int(X : Integer)`                                                                                       |
+| `put_int_stderr`             | `void put_int_stderr(const int)`                       | `procedure Put_Int_Stderr(X : Integer)`                                                                                |
+
+# Symbol definitions
+
+## `log_debug`
+
+### Signature
+
+ - C: `void log_debug(char *)`
+ - Ada: `procedure Log_Debug(Msg : String)`
+
+ * Msg: Log message
+
+### Semantics
+
+Prints log message with debug priority.
+
+## `log_warning`
+
+### Signature
+
+ - C: `void log_warning(char *)`
+ - Ada: `procedure Log_Warning(Msg : String)`
+
+ * Msg: Log message
+
+### Semantics
+
+Prints log message with warning priority.
+
+## `log_error`
+
+### Signature
+
+ - C: `void log_error(char *)`
+ - Ada: `procedure Log_Error(Msg : String)`
+
+ * Msg: Log message
+
+### Semantics
+
+Prints log message with error priority.
+
+## `__gnat_malloc`
+
+### Signature
+ 
+ - C: `void *__gnat_malloc(size_t)`
+ - Ada: `function Malloc(Size : Natural) return System.Address`
+
+ * Size: Memory size that shall be allocated
+
+### Semantics
+
+Allocates memory on the heap. When Size is 0 a null pointer should be returned.
+
+## `__gnat_free`
+
+### Signature
+
+ - C: `void __gnat_free(void *)`
+ - Ada: `procedure Free(Ptr : System.Address)`
+
+ * Ptr: Address of memory range that should be freed
+
+### Semantics
+
+Frees (only) memory allocated by `__gnat_malloc`. Should do nothing if Ptr is a null pointer.
+
+## `__gnat_unhandled_terminate`
+
+### Signature
+
+ - C: `void __gnat_unhandled_terminate()`
+ - Ada: `procedure Unhandled_Terminate`
+
+### Semantics
+
+Called if an exception has been raised and no exception handler is able to catch it. Should terminate the program.
+
+## `allocate_secondary_stack`
+
+### Signature
+
+ - C: `void *allocate_secondary_stack(void *, size_t)`
+ - Ada: `function Allocate_Secondary_Stack(Thread : System.Address; Size : Natural) return System.Address`
+
+ * Thread: thread ID of the current thread
+ * Size: size of the stack frame to be allocated
+
+### Semantics
+
+Allocates a secondary stack frame in this thread. As the thread grows downwards the returned address must be the upper address of the stack frame. While the thread ID is a pointer type it can be of any value and must not be a valid address (at least not inside the runtime). The only condition is that it is not `0` as this is the reserved invalid thread ID.
+
+## `get_thread`
+
+### Signature
+
+ - C: `void *get_thread()`
+ - Ada `function Get_Thread return System.Address`
+
+### Semantics
+
+Returns the ID of the current thread. This ID is used in `allocate_secondary_stack` and can be anything except `0` which is the reserved invalid thread ID.
+
+## `raise_ada_exception`
+
+### Signature
+
+ - C: `void raise_ada_exception(exception_t, char *, char*)`
+ - Ada: `procedure Raise_Ada_Exception(T : Exception_Type; Name : String; Msg : String)`
+
+ * T: Type of the exception (enum)
+ * Name: Name of the raised exception (or short description)
+ * Msg: Exception message
+
+### Semantics
+
+Called when any exception is raised. The Name is usually the name of the Ada exception or a short description of it. In this runtime Msg consists of the file name and line number of the exception occurrence.
+
+## `put_char`
+
+### Signature
+
+ - C: `void put_char(const char)`
+ - Ada: `procedure Put_Char(C : Character)`
+
+### Semantics
+
+Called to output a single character to standard output.
+
+## `put_char_stderr`
+
+### Signature
+
+ - C: `void put_char_stderr(const char)`
+ - Ada: `procedure Put_Char_Stderr(C : Character)`
+
+### Semantics
+
+Called to output a single character to standard error.
+
+## `put_int`
+
+### Signature
+
+ - C: `void put_int(const int)`
+ - Ada: `procedure Put_Int(X : Integer)`
+
+### Semantics
+
+Called to output a single integer to standard output.
+
+## `put_int_stderr`
+
+### Signature
+
+ - C: `void put_int_stderr(const int)`
+ - Ada: `procedure Put_Int_Stderr(X : Integer)`
+
+### Semantics
+
+Called to output a single integer to standard error.

--- a/platform/genode.cc
+++ b/platform/genode.cc
@@ -12,14 +12,48 @@
 #include <base/exception.h>
 #include <base/log.h>
 #include <base/thread.h>
+#include <base/snprintf.h>
 #include <util/string.h>
+#include <terminal_session/connection.h>
 
 #include <ada/exception.h>
 #include <ada_exceptions.h>
 
 class Gnat_Exception : public Genode::Exception {};
 
+Terminal::Connection *__genode_terminal __attribute__((weak)) = nullptr;
+
 extern "C" {
+
+    void put_char(const char c)
+    {
+        if (__genode_terminal)
+        {
+            __genode_terminal->write(&c, 1);
+        }
+    }
+
+    void put_char_stderr(const char c)
+    {
+        /* FIXME: We should output stderr via LOG */
+        put_char(c);
+    }
+
+    void put_int(const int i)
+    {
+        if (__genode_terminal)
+        {
+            char buf[20];
+            int len = Genode::snprintf(buf, sizeof(buf), "%d", i);
+            __genode_terminal->write(buf, len);
+        }
+    }
+
+   void put_int_stderr(const int i)
+   {
+        /* FIXME: We should output stderr via LOG */
+        put_int(i);
+   }
 
     void log_debug(char *message)
     {

--- a/platform/posix.c
+++ b/platform/posix.c
@@ -63,3 +63,11 @@ void raise_ada_exception(int exception, char *name, char *message) {
 LOG(debug)
 LOG(warning)
 LOG(error)
+
+void put_char (const char c) {
+   putc(c, stdout);
+}
+
+void put_int (const int i) {
+   printf("%d", i);
+}


### PR DESCRIPTION
Add functions necessary to support GNAT.IO, a stripped-down version of Text_IO. This is in preparation of a port of AUnit to Genode, which uses GNAT.IO. Originally I considered putting this into a dedicate file, so it can be built as a separate library. Given the low complexity, I don't think this is justified (yet).