### PR TITLE
Issue 22

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,10 @@ SRC = a-except.adb \
       system.ads \
       argv.c \
       exit.c \
-      init.c
+      init.c \
+      gnat.ads \
+      g-io.adb \
+      a-reatim.adb \
 
 ifneq ($(USE_GNATIO),)
 SRC += gnat.ads g-io.ads g-io.adb

--- a/contrib/gcc-6.3.0/g-io.adb
+++ b/contrib/gcc-6.3.0/g-io.adb
@@ -29,7 +29,9 @@
 --                                                                          --
 ------------------------------------------------------------------------------
 
-package body GNAT.IO is
+package body GNAT.IO
+   with SPARK_Mode => Off
+is
 
    Current_Out : File_Type := Stdout;
    pragma Atomic (Current_Out);

--- a/contrib/gcc-6.3.0/g-io.ads
+++ b/contrib/gcc-6.3.0/g-io.ads
@@ -38,7 +38,9 @@
 --  Note that Data_Error is not raised by these subprograms for bad data.
 --  If such checks are needed then the regular Text_IO package must be used.
 
-package GNAT.IO is
+package GNAT.IO
+   with SPARK_Mode
+is
    pragma Preelaborate;
 
    type File_Type is limited private;

--- a/doc/Platform-interface.md
+++ b/doc/Platform-interface.md
@@ -18,6 +18,7 @@
 | `__ada_runtime_rt_initialize`      | `void __ada_runtime_rt_initialize(void)`               | `procedure Initialize`                                                                              |
 | `__ada_runtime_rt_monotonic_clock` | `u_int64_t __ada_runtime_rt_monotonic_clock(void)`     | `function Monotonic_Clock return Time`                                                              |
 | `__ada_runtime_rt_resolution`      | `u_int64_t __ada_runtime_rt_resolution(void)`          | `function RT_Resolution return Duration`                                                            |
+| `__ada_runtime_exit_status`        | `int __ada_runtime_exit_status`                        | n/a                                                                                                 |
 
 
 # Symbol definitions
@@ -238,3 +239,14 @@ Return amount of time elapsed since epoch in Nanoseconds.
 
 Return the average time interval during which the clock interval obtained by
 calling `__ada_runtime_rt_monotonic_clock` remains constant in Nanoseconds.
+
+## `__ada_runtime_exit_status`
+
+### Signature
+
+ - C: `int __ada_runtime_exit_status`
+
+### Semantics
+
+Contains the applications exit status as set by
+`Ada.Command_Line.Set_Exit_Status`.

--- a/doc/Platform-interface.md
+++ b/doc/Platform-interface.md
@@ -1,18 +1,24 @@
-| Symbol                       | C signature                                            | Ada signature                                                                                      |
-|------------------------------|--------------------------------------------------------|----------------------------------------------------------------------------------------------------|
-| `log_debug`                  | `void log_debug(char *)`                               | `procedure Log_Debug(Msg : String)`                                                                |
-| `log_warning`                | `void log_warning(char *)`                             | `procedure Log_Warning(Msg : String)`                                                              |
-| `log_error`                  | `void log_error(char *)`                               | `procedure Log_Error(Msg : String)`                                                                |
-| `__gnat_malloc`              | `void *__gnat_malloc(size_t)`                          | `function Malloc(Size : Natural) return System.Address`                                            |
-| `__gnat_free`                | `void __gnat_free(void *)`                             | `procedure Free(Ptr : System.Address)`                                                             |
-| `__gnat_unhandled_terminate` | `void __gnat_unhandled_terminate()`                    | `procedure Unhandled_Terminate`                                                                    |
-| `allocate_secondary_stack`   | `void *allocate_secondary_stack(void *, size_t)`       | `function Allocate_Secondary_Stack(Thread : System.Address; Size : Natural) return System.Address` |
-| `get_thread`                 | `void *get_thread()`                                   | `function Get_Thread return System.Address`                                                        |
-| `raise_ada_exception`        | `void raise_ada_exception(exception_t, char *, char*)` | `procedure Raise_Ada_Exception(T : Exception_Type; Name : String; Msg : String)`                                       |
-| `put_char`                   | `void put_char(const char)`                            | `procedure Put_Char(C : Character)`                                                                                    |
-| `put_char_stderr`            | `void put_char_stderr(const char)`                     | `procedure Put_Char_Stderr(C : Character)`                                                                             |
-| `put_int`                    | `void put_int(const int)`                              | `procedure Put_Int(X : Integer)`                                                                                       |
-| `put_int_stderr`             | `void put_int_stderr(const int)`                       | `procedure Put_Int_Stderr(X : Integer)`                                                                                |
+| Symbol                             | C signature                                            | Ada signature                                                                                       |
+|------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| `log_debug`                        | `void log_debug(char *)`                               | `procedure Log_Debug (Msg : String)`                                                                |
+| `log_warning`                      | `void log_warning(char *)`                             | `procedure Log_Warning (Msg : String)`                                                              |
+| `log_error`                        | `void log_error(char *)`                               | `procedure Log_Error (Msg : String)`                                                                |
+| `__gnat_malloc`                    | `void *__gnat_malloc(size_t)`                          | `function Malloc (Size : Natural) return System.Address`                                            |
+| `__gnat_free`                      | `void __gnat_free(void *)`                             | `procedure Free (Ptr : System.Address)`                                                             |
+| `__gnat_unhandled_terminate`       | `void __gnat_unhandled_terminate()`                    | `procedure Unhandled_Terminate`                                                                     |
+| `allocate_secondary_stack`         | `void *allocate_secondary_stack(void *, size_t)`       | `function Allocate_Secondary_Stack (Thread : System.Address; Size : Natural) return System.Address` |
+| `get_thread`                       | `void *get_thread()`                                   | `function Get_Thread return System.Address`                                                         |
+| `raise_ada_exception`              | `void raise_ada_exception(exception_t, char *, char*)` | `procedure Raise_Ada_Exception (T : Exception_Type; Name : String; Msg : String)`                   |
+| `put_char`                         | `void put_char(const char)`                            | `procedure Put_Char (C : Character)`                                                                |
+| `put_char_stderr`                  | `void put_char_stderr(const char)`                     | `procedure Put_Char_Stderr (C : Character)`                                                         |
+| `get_char`                         | `char get_char(void)`                                  | `function Get_Char (C : Character) return Character`                                                |
+| `put_int`                          | `void put_int(const int)`                              | `procedure Put_Int (X : Integer)`                                                                   |
+| `put_int_stderr`                   | `void put_int_stderr(const int)`                       | `procedure Put_Int_Stderr (X : Integer)`                                                            |
+| `get_int`                          | `int get_int(void)`                                    | `function Get_Int return Integer`                                                                   |
+| `__ada_runtime_rt_initialize`      | `void __ada_runtime_rt_initialize(void)`               | `procedure Initialize`                                                                              |
+| `__ada_runtime_rt_monotonic_clock` | `u_int64_t __ada_runtime_rt_monotonic_clock(void)`     | `function Monotonic_Clock return Time`                                                              |
+| `__ada_runtime_rt_resolution`      | `u_int64_t __ada_runtime_rt_resolution(void)`          | `function RT_Resolution return Duration`                                                            |
+
 
 # Symbol definitions
 
@@ -143,6 +149,17 @@ Called when any exception is raised. The Name is usually the name of the Ada exc
 
 Called to output a single character to standard output.
 
+## `get_char`
+
+### Signature
+
+ - C: `char get_char(voi)`
+ - Ada: `function Get_Char return Character`
+
+### Semantics
+
+Called to read a single character from standard output.
+
 ## `put_char_stderr`
 
 ### Signature
@@ -165,6 +182,17 @@ Called to output a single character to standard error.
 
 Called to output a single integer to standard output.
 
+## `get_int`
+
+### Signature
+
+ - C: `int get_int(voi)`
+ - Ada: `function Get_Int return Integer`
+
+### Semantics
+
+Called to read a single integer from standard input.
+
 ## `put_int_stderr`
 
 ### Signature
@@ -175,3 +203,38 @@ Called to output a single integer to standard output.
 ### Semantics
 
 Called to output a single integer to standard error.
+
+## `__ada_runtime_rt_initialize`
+
+### Signature
+
+ - C: `void __ada_runtime_rt_initialize(void)`
+ - Ada: `procedure Initialize`
+
+### Semantics
+
+Perform initialization required to use `__ada_runtime_rt_monotonic_clock`  and
+`__ada_runtime_rt_resolution`.
+
+## `__ada_runtime_rt_monotonic_clock`
+
+### Signature
+
+ - C: `u_int64_t __ada_runtime_rt_monotonic_clock(void)`
+ - Ada: `function Monotonic_Clock return Time`
+
+### Semantics
+
+Return amount of time elapsed since epoch in Nanoseconds.
+
+## `__ada_runtime_rt_resolution`
+
+### Signature
+
+ - C: `u_int64_t __ada_runtime_rt_resolution(void)`
+ - Ada: `function RT_Resolution return Duration`
+
+### Semantics
+
+Return the average time interval during which the clock interval obtained by
+calling `__ada_runtime_rt_monotonic_clock` remains constant in Nanoseconds.

--- a/platform/posix_common.c
+++ b/platform/posix_common.c
@@ -101,5 +101,5 @@ u_int64_t __ada_runtime_rt_monotonic_clock(void) {
 }
 
 void __ada_runtime_rt_initialize(void) {
-}
    // empty
+}

--- a/platform/posix_common.c
+++ b/platform/posix_common.c
@@ -12,6 +12,8 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
+#include <time.h>
 
 void __gnat_unhandled_terminate() {
     printf("error: unhandled exception\n");
@@ -71,3 +73,25 @@ void put_int (const int i) {
 void put_int_stderr (const int i) {
    fprintf(stderr, "%d", i);
 }
+
+u_int64_t __ada_runtime_rt_resolution(void) {
+   int rv;
+   struct timespec res;
+
+   rv = clock_getres (CLOCK_MONOTONIC, &res);
+   assert(rv == 0);
+   return res.tv_sec * 1000000000UL + res.tv_nsec;
+}
+
+u_int64_t __ada_runtime_rt_monotonic_clock(void) {
+   int rv;
+   struct timespec res;
+
+   rv = clock_gettime (CLOCK_MONOTONIC, &res);
+   assert(rv == 0);
+   return res.tv_sec * 1000000000UL + res.tv_nsec;
+}
+
+void __ada_runtime_rt_initialize(void) {
+}
+   // empty

--- a/platform/posix_common.c
+++ b/platform/posix_common.c
@@ -62,6 +62,10 @@ void put_char (const char c) {
    putc(c, stdout);
 }
 
+char get_char (void) {
+   return (char)0;
+}
+
 void put_char_stderr (const char c) {
    putc(c, stderr);
 }
@@ -72,6 +76,10 @@ void put_int (const int i) {
 
 void put_int_stderr (const int i) {
    fprintf(stderr, "%d", i);
+}
+
+int get_int (void) {
+   return 0;
 }
 
 u_int64_t __ada_runtime_rt_resolution(void) {

--- a/restrictions.adc
+++ b/restrictions.adc
@@ -3,7 +3,6 @@ pragma Restrictions (No_Calendar);
 pragma Restrictions (No_Dispatch);
 pragma Restrictions (No_Enumeration_Maps);
 pragma Restrictions (No_Exception_Handlers);
-pragma Restrictions (No_Fixed_Point);
 pragma Restrictions (No_Implicit_Dynamic_Code);
 pragma Restrictions (No_Initialize_Scalars);
 pragma Restrictions (No_IO);

--- a/src/common/a-reatim.adb
+++ b/src/common/a-reatim.adb
@@ -1,0 +1,396 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                 GNAT RUN-TIME LIBRARY (GNARL) COMPONENTS                 --
+--                                                                          --
+--                         A D A . R E A L _ T I M E                        --
+--                                                                          --
+--                                 B o d y                                  --
+--                                                                          --
+--             Copyright (C) 1991-1994, Florida State University            --
+--                     Copyright (C) 1995-2015, AdaCore                     --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNARL was developed by the GNARL team at Florida State University.       --
+-- Extensive contributions were provided by Ada Core Technologies, Inc.     --
+--                                                                          --
+------------------------------------------------------------------------------
+
+with Ada.Unchecked_Conversion;
+
+package body Ada.Real_Time with
+  SPARK_Mode => Off
+is
+
+   ---------
+   -- "*" --
+   ---------
+
+   --  Note that Constraint_Error may be propagated
+
+   function "*" (Left : Time_Span; Right : Integer) return Time_Span is
+      pragma Unsuppress (Overflow_Check);
+   begin
+      return Time_Span (Duration (Left) * Right);
+   end "*";
+
+   function "*" (Left : Integer; Right : Time_Span) return Time_Span is
+      pragma Unsuppress (Overflow_Check);
+   begin
+      return Time_Span (Left * Duration (Right));
+   end "*";
+
+   ---------
+   -- "+" --
+   ---------
+
+   --  Note that Constraint_Error may be propagated
+
+   function "+" (Left : Time; Right : Time_Span) return Time is
+      pragma Unsuppress (Overflow_Check);
+   begin
+      return Time (Duration (Left) + Duration (Right));
+   end "+";
+
+   function "+" (Left : Time_Span; Right : Time) return Time is
+      pragma Unsuppress (Overflow_Check);
+   begin
+      return Time (Duration (Left) + Duration (Right));
+   end "+";
+
+   function "+" (Left, Right : Time_Span) return Time_Span is
+      pragma Unsuppress (Overflow_Check);
+   begin
+      return Time_Span (Duration (Left) + Duration (Right));
+   end "+";
+
+   ---------
+   -- "-" --
+   ---------
+
+   --  Note that Constraint_Error may be propagated
+
+   function "-" (Left : Time; Right : Time_Span) return Time is
+      pragma Unsuppress (Overflow_Check);
+   begin
+      return Time (Duration (Left) - Duration (Right));
+   end "-";
+
+   function "-" (Left, Right : Time) return Time_Span is
+      pragma Unsuppress (Overflow_Check);
+   begin
+      return Time_Span (Duration (Left) - Duration (Right));
+   end "-";
+
+   function "-" (Left, Right : Time_Span) return Time_Span is
+      pragma Unsuppress (Overflow_Check);
+   begin
+      return Time_Span (Duration (Left) - Duration (Right));
+   end "-";
+
+   function "-" (Right : Time_Span) return Time_Span is
+      pragma Unsuppress (Overflow_Check);
+   begin
+      return Time_Span_Zero - Right;
+   end "-";
+
+   ---------
+   -- "/" --
+   ---------
+
+   --  Note that Constraint_Error may be propagated
+
+   function "/" (Left, Right : Time_Span) return Integer is
+      pragma Unsuppress (Overflow_Check);
+      pragma Unsuppress (Division_Check);
+
+      --  RM D.8 (27) specifies the effects of operators on Time_Span, and
+      --  rounding of the division operator in particular, to be the same as
+      --  effects on integer types. To get the correct rounding we first
+      --  convert Time_Span to its root type Duration, which is represented as
+      --  a 64-bit signed integer, and then use integer division.
+
+      type Duration_Rep is range -(2 ** 63) .. +((2 ** 63 - 1));
+
+      function To_Integer is
+        new Ada.Unchecked_Conversion (Duration, Duration_Rep);
+   begin
+      return Integer
+               (To_Integer (Duration (Left)) / To_Integer (Duration (Right)));
+   end "/";
+
+   function "/" (Left : Time_Span; Right : Integer) return Time_Span is
+      pragma Unsuppress (Overflow_Check);
+      pragma Unsuppress (Division_Check);
+   begin
+      --  Even though checks are unsuppressed, we need an explicit check for
+      --  the case of largest negative integer divided by minus one, since
+      --  some library routines we use fail to catch this case. This will be
+      --  fixed at the compiler level in the future, at which point this test
+      --  can be removed.
+
+      if Left = Time_Span_First and then Right = -1 then
+         raise Constraint_Error with "overflow";
+      end if;
+
+      return Time_Span (Duration (Left) / Right);
+   end "/";
+
+   -----------
+   -- Clock --
+   -----------
+
+   function Clock return Time
+   is
+      function Monotonic_Clock return Time
+      with Import,
+           Convention => C,
+           External_Name => "__ada_runtime_rt_monotonic_clock";
+   begin
+      return Monotonic_Clock;
+   end Clock;
+
+   ------------------
+   -- Microseconds --
+   ------------------
+
+   function Microseconds (US : Integer) return Time_Span is
+   begin
+      return Time_Span_Unit * US * 1_000;
+   end Microseconds;
+
+   ------------------
+   -- Milliseconds --
+   ------------------
+
+   function Milliseconds (MS : Integer) return Time_Span is
+   begin
+      return Time_Span_Unit * MS * 1_000_000;
+   end Milliseconds;
+
+   -------------
+   -- Minutes --
+   -------------
+
+   function Minutes (M : Integer) return Time_Span is
+   begin
+      return Milliseconds (M) * Integer'(60_000);
+   end Minutes;
+
+   -----------------
+   -- Nanoseconds --
+   -----------------
+
+   function Nanoseconds (NS : Integer) return Time_Span is
+   begin
+      return Time_Span_Unit * NS;
+   end Nanoseconds;
+
+   -------------
+   -- Seconds --
+   -------------
+
+   function Seconds (S : Integer) return Time_Span is
+   begin
+      return Milliseconds (S) * Integer'(1000);
+   end Seconds;
+
+   -----------
+   -- Split --
+   -----------
+
+   procedure Split (T : Time; SC : out Seconds_Count; TS : out Time_Span) is
+      T_Val : Time;
+
+   begin
+      --  Special-case for Time_First, whose absolute value is anomalous,
+      --  courtesy of two's complement.
+
+      T_Val := (if T = Time_First then abs (Time_Last) else abs (T));
+
+      --  Extract the integer part of T, truncating towards zero
+
+      SC :=
+        (if T_Val < 0.5 then 0 else Seconds_Count (Time_Span'(T_Val - 0.5)));
+
+      if T < 0.0 then
+         SC := -SC;
+      end if;
+
+      --  If original time is negative, need to truncate towards negative
+      --  infinity, to make TS non-negative, as per ARM.
+
+      if Time (SC) > T then
+         SC := SC - 1;
+      end if;
+
+      TS := Time_Span (Duration (T) - Duration (SC));
+   end Split;
+
+   -------------
+   -- Time_Of --
+   -------------
+
+   function Time_Of (SC : Seconds_Count; TS : Time_Span) return Time is
+      pragma Suppress (Overflow_Check);
+      pragma Suppress (Range_Check);
+      --  We do all our own checks for this function
+
+      --  This is not such a simple case, since TS is already 64 bits, and
+      --  so we can't just promote everything to a wider type to ensure proper
+      --  testing for overflow. The situation is that Seconds_Count is a MUCH
+      --  wider type than Time_Span and Time (both of which have the underlying
+      --  type Duration).
+
+      --         <------------------- Seconds_Count -------------------->
+      --                            <-- Duration -->
+
+      --  Now it is possible for an SC value outside the Duration range to
+      --  be "brought back into range" by an appropriate TS value, but there
+      --  are also clearly SC values that are completely out of range. Note
+      --  that the above diagram is wildly out of scale, the difference in
+      --  ranges is much greater than shown.
+
+      --  We can't just go generating out of range Duration values to test for
+      --  overflow, since Duration is a full range type, so we follow the steps
+      --  shown below.
+
+      SC_Lo : constant Seconds_Count :=
+                Seconds_Count (Duration (Time_Span_First) + Duration'(0.5));
+      SC_Hi : constant Seconds_Count :=
+                Seconds_Count (Duration (Time_Span_Last)  - Duration'(0.5));
+      --  These are the maximum values of the seconds (integer) part of the
+      --  Duration range. Used to compute and check the seconds in the result.
+
+      TS_SC : Seconds_Count;
+      --  Seconds part of input value
+
+      TS_Fraction : Duration;
+      --  Fractional part of input value, may be negative
+
+      Result_SC : Seconds_Count;
+      --  Seconds value for result
+
+      Fudge : constant Seconds_Count := 10;
+      --  Fudge value used to do end point checks far from end point
+
+      FudgeD : constant Duration := Duration (Fudge);
+      --  Fudge value as Duration
+
+      Fudged_Result : Duration;
+      --  Result fudged up or down by FudgeD
+
+      procedure Out_Of_Range;
+      pragma No_Return (Out_Of_Range);
+      --  Raise exception for result out of range
+
+      ------------------
+      -- Out_Of_Range --
+      ------------------
+
+      procedure Out_Of_Range is
+      begin
+         raise Constraint_Error with
+           "result for Ada.Real_Time.Time_Of is out of range";
+      end Out_Of_Range;
+
+   --  Start of processing for Time_Of
+
+   begin
+      --  If SC is so far out of range that there is no possibility of the
+      --  addition of TS getting it back in range, raise an exception right
+      --  away. That way we don't have to worry about SC values overflowing.
+
+      if SC < 3 * SC_Lo or else SC > 3 * SC_Hi then
+         Out_Of_Range;
+      end if;
+
+      --  Decompose input TS value
+
+      TS_SC := Seconds_Count (Duration (TS));
+      TS_Fraction := Duration (TS) - Duration (TS_SC);
+
+      --  Compute result seconds. If clearly out of range, raise error now
+
+      Result_SC := SC + TS_SC;
+
+      if Result_SC < (SC_Lo - 1) or else Result_SC > (SC_Hi + 1) then
+         Out_Of_Range;
+      end if;
+
+      --  Now the result is simply Result_SC + TS_Fraction, but we can't just
+      --  go computing that since it might be out of range. So what we do is
+      --  to compute a value fudged down or up by 10.0 (arbitrary value, but
+      --  that will do fine), and check that fudged value, and if in range
+      --  unfudge it and return the result.
+
+      --  Fudge positive result down, and check high bound
+
+      if Result_SC > 0 then
+         Fudged_Result := Duration (Result_SC - Fudge) + TS_Fraction;
+
+         if Fudged_Result <= Duration'Last - FudgeD then
+            return Time (Fudged_Result + FudgeD);
+         else
+            Out_Of_Range;
+         end if;
+
+      --  Same for negative values of seconds, fudge up and check low bound
+
+      else
+         Fudged_Result := Duration (Result_SC + Fudge) + TS_Fraction;
+
+         if Fudged_Result >= Duration'First + FudgeD then
+            return Time (Fudged_Result - FudgeD);
+         else
+            Out_Of_Range;
+         end if;
+      end if;
+   end Time_Of;
+
+   -----------------
+   -- To_Duration --
+   -----------------
+
+   function To_Duration (TS : Time_Span) return Duration is
+   begin
+      return Duration (TS);
+   end To_Duration;
+
+   ------------------
+   -- To_Time_Span --
+   ------------------
+
+   function To_Time_Span (D : Duration) return Time_Span is
+   begin
+      --  Note regarding AI-00432 requiring range checking on this conversion.
+      --  In almost all versions of GNAT (and all to which this version of the
+      --  Ada.Real_Time package apply), the range of Time_Span and Duration are
+      --  the same, so there is no issue of overflow.
+
+      return Time_Span (D);
+   end To_Time_Span;
+
+   procedure Initialize
+   with
+      Import,
+      Convention => C,
+      External_Name => "__ada_runtime_rt_initialize";
+
+begin
+   Initialize;
+end Ada.Real_Time;

--- a/src/common/a-reatim.ads
+++ b/src/common/a-reatim.ads
@@ -1,0 +1,187 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                         GNAT RUN-TIME COMPONENTS                         --
+--                                                                          --
+--                         A D A . R E A L _ T I M E                        --
+--                                                                          --
+--                                  S p e c                                 --
+--                                                                          --
+--          Copyright (C) 1992-2015, Free Software Foundation, Inc.         --
+--                                                                          --
+-- This specification is derived from the Ada Reference Manual for use with --
+-- GNAT. The copyright notice above, and the license provisions that follow --
+-- apply solely to the  contents of the part following the private keyword. --
+--                                                                          --
+-- GNAT is free software;  you can  redistribute it  and/or modify it under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  GNAT is distributed in the hope that it will be useful, but WITH- --
+-- OUT ANY WARRANTY;  without even the  implied warranty of MERCHANTABILITY --
+-- or FITNESS FOR A PARTICULAR PURPOSE.                                     --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-- GNAT was originally developed  by the GNAT team at  New York University. --
+-- Extensive contributions were provided by Ada Core Technologies Inc.      --
+--                                                                          --
+------------------------------------------------------------------------------
+
+package Ada.Real_Time with
+  SPARK_Mode,
+  Abstract_State => (Clock_Time with Synchronous,
+                                     External => (Async_Readers,
+                                                  Async_Writers))
+is
+
+   pragma Compile_Time_Error
+     (Duration'Size /= 64,
+      "this version of Ada.Real_Time requires 64-bit Duration");
+
+   type Time is private;
+   Time_First : constant Time;
+   Time_Last  : constant Time;
+   Time_Unit  : constant := 10#1.0#E-9;
+
+   type Time_Span is private;
+   Time_Span_First : constant Time_Span;
+   Time_Span_Last  : constant Time_Span;
+   Time_Span_Zero  : constant Time_Span;
+   Time_Span_Unit  : constant Time_Span;
+
+   Tick : constant Time_Span;
+   function Clock return Time with
+     Volatile_Function,
+     Global => Clock_Time;
+
+   function "+"  (Left : Time;      Right : Time_Span) return Time with
+     Global => null;
+   function "+"  (Left : Time_Span; Right : Time)      return Time with
+     Global => null;
+   function "-"  (Left : Time;      Right : Time_Span) return Time with
+     Global => null;
+   function "-"  (Left : Time;      Right : Time)      return Time_Span with
+     Global => null;
+
+   function "<"  (Left, Right : Time) return Boolean with
+     Global => null;
+   function "<=" (Left, Right : Time) return Boolean with
+     Global => null;
+   function ">"  (Left, Right : Time) return Boolean with
+     Global => null;
+   function ">=" (Left, Right : Time) return Boolean with
+     Global => null;
+
+   function "+"  (Left, Right : Time_Span)             return Time_Span with
+     Global => null;
+   function "-"  (Left, Right : Time_Span)             return Time_Span with
+     Global => null;
+   function "-"  (Right : Time_Span)                   return Time_Span with
+     Global => null;
+   function "*"  (Left : Time_Span; Right : Integer)   return Time_Span with
+     Global => null;
+   function "*"  (Left : Integer;   Right : Time_Span) return Time_Span with
+     Global => null;
+   function "/"  (Left, Right : Time_Span)             return Integer with
+     Global => null;
+   function "/"  (Left : Time_Span; Right : Integer)   return Time_Span with
+     Global => null;
+
+   function "abs" (Right : Time_Span) return Time_Span with
+     Global => null;
+
+   function "<"  (Left, Right : Time_Span) return Boolean with
+     Global => null;
+   function "<=" (Left, Right : Time_Span) return Boolean with
+     Global => null;
+   function ">"  (Left, Right : Time_Span) return Boolean with
+     Global => null;
+   function ">=" (Left, Right : Time_Span) return Boolean with
+     Global => null;
+
+   function To_Duration  (TS : Time_Span) return Duration with
+     Global => null;
+   function To_Time_Span (D : Duration)   return Time_Span with
+     Global => null;
+
+   function Nanoseconds  (NS : Integer) return Time_Span with
+     Global => null;
+   function Microseconds (US : Integer) return Time_Span with
+     Global => null;
+   function Milliseconds (MS : Integer) return Time_Span with
+     Global => null;
+
+   function Seconds (S : Integer) return Time_Span with
+     Global => null;
+   pragma Ada_05 (Seconds);
+
+   function Minutes (M : Integer) return Time_Span with
+     Global => null;
+   pragma Ada_05 (Minutes);
+
+   type Seconds_Count is new Long_Long_Integer;
+   --  Seconds_Count needs 64 bits, since the type Time has the full range of
+   --  Duration. The delta of Duration is 10 ** (-9), so the maximum number of
+   --  seconds is 2**63/10**9 = 8*10**9 which does not quite fit in 32 bits.
+   --  However, rather than make this explicitly 64-bits we derive from
+   --  Long_Long_Integer. In normal usage this will have the same effect. But
+   --  in the case of CodePeer with a target configuration file with a maximum
+   --  integer size of 32, it allows analysis of this unit.
+
+   procedure Split (T : Time; SC : out Seconds_Count; TS : out Time_Span)
+   with
+     Global => null;
+   function Time_Of (SC : Seconds_Count; TS : Time_Span) return Time
+   with
+     Global => null;
+
+private
+   pragma SPARK_Mode (Off);
+
+   --  Time and Time_Span are represented in 64-bit Duration value in
+   --  nanoseconds. For example, 1 second and 1 nanosecond is represented
+   --  as the stored integer 1_000_000_001. This is for the 64-bit Duration
+   --  case, not clear if this also is used for 32-bit Duration values.
+
+   type Time is new Duration;
+
+   Time_First : constant Time := Time'First;
+
+   Time_Last  : constant Time := Time'Last;
+
+   type Time_Span is new Duration;
+
+   Time_Span_First : constant Time_Span := Time_Span'First;
+
+   Time_Span_Last  : constant Time_Span := Time_Span'Last;
+
+   Time_Span_Zero  : constant Time_Span := 0.0;
+
+   Time_Span_Unit  : constant Time_Span := 10#1.0#E-9;
+
+   function RT_Resolution return Duration
+   with Import,
+        Convention => C,
+        External_Name => "__ada_runtime_rt_resolution";
+
+   Tick : constant Time_Span := Time_Span (RT_Resolution);
+
+   pragma Import (Intrinsic, "<");
+   pragma Import (Intrinsic, "<=");
+   pragma Import (Intrinsic, ">");
+   pragma Import (Intrinsic, ">=");
+   pragma Import (Intrinsic, "abs");
+
+   pragma Inline (Microseconds);
+   pragma Inline (Milliseconds);
+   pragma Inline (Nanoseconds);
+   pragma Inline (Seconds);
+   pragma Inline (Minutes);
+
+end Ada.Real_Time;

--- a/src/lib/exit.c
+++ b/src/lib/exit.c
@@ -1,6 +1,11 @@
+/* this symbol is required/expected by the binder */
 int gnat_exit_status = 0;
+
+/* this symbol is required/expected by the runtime */
+int __ada_runtime_exit_status = 0;
 
 void __gnat_set_exit_status (int value)
 {
    gnat_exit_status = value;
+   __ada_runtime_exit_status = value;
 };

--- a/src/minimal/s-soflin.adb
+++ b/src/minimal/s-soflin.adb
@@ -25,14 +25,13 @@ package body System.Soft_Links is
 
    function Get_Jmpbuf_Address_Soft return Address is
    begin
-      Platform.Log_Warning ("Get_Jmpbuf_Address_Soft not implemented");
       return Address (0);
    end Get_Jmpbuf_Address_Soft;
 
    procedure Set_Jmpbuf_Address_Soft (Addr : Address) is
       pragma Unreferenced (Addr);
    begin
-      Platform.Log_Warning ("Set_Jmpbuf_Address_Soft not implemented");
+      null;
    end Set_Jmpbuf_Address_Soft;
 
 end System.Soft_Links;


### PR DESCRIPTION
* Add support for Ada.Real_Time on POSIX and Genode platforms
* Only pass Genode::Env pointer to runtime and create other required sessions on demand using reconstructibles
* Make GNAT.IO SPARK compatible
* Implement missing dummies for `get_char` / `get_int`
* Document `get_char` and `get_int` in platform interface documentation
* Mute jmbuf-related log messages

Closes #22