### PR TITLE
Secondary stack with binder allocation

### DIFF
--- a/platform/componolit_runtime.ads
+++ b/platform/componolit_runtime.ads
@@ -16,12 +16,6 @@ is
                                   N : String;
                                   M : String);
 
-   procedure Allocate_Secondary_Stack (Size :     Natural;
-                                       Addr : out System.Address) with
-      Export,
-      Convention => C,
-      External_Name => "componolit_runtime_allocate_secondary_stack";
-
    procedure Initialize with
       Export,
       Convention => C,

--- a/platform/componolit_runtime.h
+++ b/platform/componolit_runtime.h
@@ -16,8 +16,6 @@ void componolit_runtime_log_error(char *);
 
 void componolit_runtime_raise_ada_exception(exception_t, char *, char *);
 
-void componolit_runtime_allocate_secondary_stack(unsigned, void **);
-
 void componolit_runtime_initialize(void);
 
 void componolit_runtime_finalize(void);

--- a/platform/genode/genode.cc
+++ b/platform/genode/genode.cc
@@ -82,11 +82,6 @@ extern "C" {
         throw Gnat_Exception();
     }
 
-    void componolit_runtime_allocate_secondary_stack(unsigned size, void **address)
-    {
-        *address = Genode::Thread::myself()->alloc_secondary_stack("ada thread", size);
-    }
-
 #define exc_case(c, cpp) case c: throw Ada::Exception::cpp()
 
     void componolit_runtime_raise_ada_exception(exception_t exception, char *name, char *message)

--- a/platform/linux/posix_common.c
+++ b/platform/linux/posix_common.c
@@ -30,18 +30,6 @@ static void make_key()
     (void) pthread_key_create(&key, NULL);
 }
 
-void componolit_runtime_allocate_secondary_stack(unsigned size, void **address) {
-    void *ptr;
-
-    (void) pthread_once(&key_once, make_key);
-    if ((ptr = pthread_getspecific(key)) == NULL) {
-        ptr = malloc(size) + size;
-        (void) pthread_setspecific(key, ptr);
-    }
-
-    *address = pthread_getspecific(key);
-}
-
 void componolit_runtime_raise_ada_exception(exception_t exception, char *name, char *message) {
     printf("Exception raised (%d): %s: %s\n", (int)exception, name, message);
     exit(0);

--- a/platform/muen/componolit_runtime.adb
+++ b/platform/muen/componolit_runtime.adb
@@ -7,23 +7,6 @@ package body Componolit_Runtime with
    SPARK_Mode
 is
 
-   type Byte is mod 2 ** 8 with
-      Size => 8;
-   type Stack is array (Natural range <>) of Byte;
-
-   Secondary_Stack : Stack (1 .. 1024 ** 2) := (others => 0);
-
-   procedure Allocate_Secondary_Stack (Size :     Natural;
-                                       Addr : out System.Address)
-   is
-   begin
-      if Size = 0 or else Size > Secondary_Stack'Last then
-         Addr := System.Null_Address;
-      else
-         Addr := Secondary_Stack (Secondary_Stack'First)'Address;
-      end if;
-   end Allocate_Secondary_Stack;
-
    procedure Log_Debug (S : String)
    is
    begin

--- a/src/lib/componolit-runtime-secondary_stack.adb
+++ b/src/lib/componolit-runtime-secondary_stack.adb
@@ -13,26 +13,11 @@ package body Componolit.Runtime.Secondary_Stack with
    SPARK_Mode
 is
 
-   procedure Check_Mark (E : in out Mark)
-   is
-   begin
-      if E.Base = Null_Address then
-         E.Top := 0;
-         C_Alloc (Secondary_Stack_Size, E.Base);
-      end if;
-      if E.Base = Null_Address then
-         Componolit.Runtime.Platform.Terminate_Message
-            ("Secondary stack allocation failed");
-      end if;
-   end Check_Mark;
-
    procedure S_Allocate (Stack_Mark   : in out Mark;
                          Address      :    out SSE.Integer_Address;
                          Storage_Size :        SSE.Storage_Count)
    is
    begin
-      Check_Mark (Stack_Mark);
-
       if
          Stack_Mark.Top < Secondary_Stack_Size
          and then Storage_Size < Secondary_Stack_Size
@@ -48,12 +33,11 @@ is
       end if;
    end S_Allocate;
 
-   procedure S_Mark (Stack_Mark : in out Mark;
-                     Stack_Base :    out SSE.Integer_Address;
-                     Stack_Ptr  :    out SSE.Storage_Count)
+   procedure S_Mark (Stack_Mark :     Mark;
+                     Stack_Base : out SSE.Integer_Address;
+                     Stack_Ptr  : out SSE.Storage_Count)
    is
    begin
-      Check_Mark (Stack_Mark);
       Stack_Base := Stack_Mark.Base;
       Stack_Ptr  := Stack_Mark.Top;
    end S_Mark;

--- a/src/lib/componolit-runtime-secondary_stack.ads
+++ b/src/lib/componolit-runtime-secondary_stack.ads
@@ -25,49 +25,33 @@ is
    Null_Address : constant SSE.Integer_Address := 0;
    Null_Mark    : constant Mark := (Base => Null_Address, Top => 0);
 
-   Secondary_Stack_Size : constant SSE.Storage_Count := 768 * 1024;
-
-   procedure Check_Mark (E : in out Mark) with
-      Contract_Cases => (E.Base = Null_Address =>
-                            (E.Base /= Null_Address
-                             and E.Top = 0),
-                         E.Base /= Null_Address =>
-                            (E.Base = E.Base'Old
-                             and E.Top = E.Top'Old));
+   Secondary_Stack_Size : SSE.Storage_Count := 0;
 
    procedure S_Allocate (Stack_Mark   : in out Mark;
                          Address      :    out SSE.Integer_Address;
                          Storage_Size :        SSE.Storage_Count) with
-      Pre  => Stack_Mark.Top < Secondary_Stack_Size
+      Pre  => Secondary_Stack_Size > 0
+              and then Stack_Mark.Base /= Null_Address
+              and then Stack_Mark.Top < Secondary_Stack_Size
               and then Storage_Size < Secondary_Stack_Size
               and then Storage_Size + Stack_Mark.Top < Secondary_Stack_Size
               and then SSE.Integer_Address (Storage_Size + Stack_Mark.Top)
                        < Stack_Mark.Base,
       Post => Stack_Mark.Base /= Null_Address and Address /= Null_Address;
 
-   procedure S_Mark (Stack_Mark : in out Mark;
-                     Stack_Base :    out SSE.Integer_Address;
-                     Stack_Ptr  :    out SSE.Storage_Count) with
-      Post => Stack_Mark.Base /= Null_Address
-              and Stack_Base /= Null_Address
-              and Stack_Base = Stack_Mark.Base;
+   procedure S_Mark (Stack_Mark :     Mark;
+                     Stack_Base : out SSE.Integer_Address;
+                     Stack_Ptr  : out SSE.Storage_Count) with
+      Post => Stack_Base /= Null_Address
+              and then Stack_Base = Stack_Mark.Base;
 
    procedure S_Release (Stack_Mark : in out Mark;
                         Stack_Base :        SSE.Integer_Address;
                         Stack_Ptr  :        SSE.Storage_Count) with
-      Pre  => Stack_Base /= Null_Address
+      Pre  => Secondary_Stack_Size > 0
+              and then Stack_Base /= Null_Address
               and then Stack_Mark.Base = Stack_Base
               and then Stack_Ptr <= Stack_Mark.Top,
       Post => Stack_Mark.Base /= Null_Address;
-
-private
-
-   procedure C_Alloc (Size    :     SSE.Storage_Count;
-                      Address : out SSE.Integer_Address) with
-      Import,
-      Convention => C,
-      External_Name => "componolit_runtime_allocate_secondary_stack",
-      Post => Address /= Null_Address,
-      Global => null;
 
 end Componolit.Runtime.Secondary_Stack;

--- a/src/lib/componolit-runtime-secondary_stack.ads
+++ b/src/lib/componolit-runtime-secondary_stack.ads
@@ -31,6 +31,8 @@ is
                          Address      :    out SSE.Integer_Address;
                          Storage_Size :        SSE.Storage_Count) with
       Pre  => Secondary_Stack_Size > 0
+              and then Secondary_Stack_Size <=
+                 SSE.Storage_Count (Integer'Last)
               and then Stack_Mark.Base /= Null_Address
               and then Stack_Mark.Top < Secondary_Stack_Size
               and then Storage_Size < Secondary_Stack_Size
@@ -42,6 +44,7 @@ is
    procedure S_Mark (Stack_Mark :     Mark;
                      Stack_Base : out SSE.Integer_Address;
                      Stack_Ptr  : out SSE.Storage_Count) with
+      Pre  => Stack_Mark.Base /= Null_Address,
       Post => Stack_Base /= Null_Address
               and then Stack_Base = Stack_Mark.Base;
 
@@ -49,6 +52,8 @@ is
                         Stack_Base :        SSE.Integer_Address;
                         Stack_Ptr  :        SSE.Storage_Count) with
       Pre  => Secondary_Stack_Size > 0
+              and then Secondary_Stack_Size <=
+                 SSE.Storage_Count (Integer'Last)
               and then Stack_Base /= Null_Address
               and then Stack_Mark.Base = Stack_Base
               and then Stack_Ptr <= Stack_Mark.Top,

--- a/src/lib/init.c
+++ b/src/lib/init.c
@@ -14,7 +14,3 @@ int   __gl_detect_blocking               = 0;
 int   __gl_default_stack_size            = -1;
 int   __gl_leap_seconds_support          = 0;
 int   __gl_exception_tracebacks          = 0;
-
-int   __gnat_binder_ss_count             = 0;
-int   __gnat_default_ss_pool             = 0;
-int   __gnat_default_ss_size             = 0;

--- a/src/minimal/s-secsta.adb
+++ b/src/minimal/s-secsta.adb
@@ -7,30 +7,40 @@
 --  additional permissions described in the GCC Runtime Library Exception,
 --  version 3.1, as published by the Free Software Foundation.
 
+with Componolit.Runtime.Platform;
+
 package body System.Secondary_Stack is
 
    procedure SS_Allocate (Address      : out SSE.Integer_Address;
                           Storage_Size :     SSE.Storage_Count)
    is
    begin
-      Componolit.Runtime.Secondary_Stack.S_Allocate
-         (Stack_Mark, Address, Storage_Size);
+      CRS.S_Allocate (Stack_Mark, Address, Storage_Size);
    end SS_Allocate;
 
    function SS_Mark return Mark_Id
    is
       M : Mark_Id;
    begin
-      Componolit.Runtime.Secondary_Stack.S_Mark
-         (Stack_Mark, M.Sstk, SSE.Storage_Count (M.Sptr));
+      CRS.S_Mark (Stack_Mark, M.Sstk, SSE.Storage_Count (M.Sptr));
       return M;
    end SS_Mark;
 
    procedure SS_Release (M : Mark_Id)
    is
    begin
-      Componolit.Runtime.Secondary_Stack.S_Release
-         (Stack_Mark, M.Sstk, SSE.Storage_Count (M.Sptr));
+      CRS.S_Release (Stack_Mark, M.Sstk, SSE.Storage_Count (M.Sptr));
    end SS_Release;
 
+   use type SSE.Integer_Address;
+begin
+   if Stack_Count = 1 then
+      Stack_Mark.Base :=
+         SSE.To_Integer (Stack_Pool_Address)
+         + SSE.Integer_Address (Stack_Size);
+   else
+      Componolit.Runtime.Platform.Terminate_Message
+         ("Invalid secondary stack count");
+   end if;
+   CRS.Secondary_Stack_Size := SSE.Storage_Count (Stack_Size);
 end System.Secondary_Stack;

--- a/src/minimal/s-secsta.ads
+++ b/src/minimal/s-secsta.ads
@@ -15,6 +15,7 @@ package System.Secondary_Stack is
 
    package SP renames System.Parameters;
    package SSE renames System.Storage_Elements;
+   package CRS renames Componolit.Runtime.Secondary_Stack;
 
    type SS_Stack (Size : SP.Size_Type) is private;
 
@@ -37,9 +38,7 @@ private
    for Memory'Alignment use Standard'Maximum_Alignment;
 
    type SS_Stack (Size : SP.Size_Type) is record
-      Top : SS_Ptr;
-      Max : SS_Ptr;
-      Internal_Chunk : Memory (1 .. Size);
+      Stack_Space : Memory (1 .. Size);
    end record;
 
    type Mark_Id is record
@@ -47,7 +46,21 @@ private
       Sptr : SSE.Integer_Address;
    end record;
 
-   Stack_Mark : Componolit.Runtime.Secondary_Stack.Mark :=
-      Componolit.Runtime.Secondary_Stack.Null_Mark;
+   Stack_Size : SP.Size_Type with
+      Export,
+      Convention => Ada,
+      External_Name => "__gnat_default_ss_size";
+
+   Stack_Count : Natural with
+      Export,
+      Convention => Ada,
+      External_Name => "__gnat_binder_ss_count";
+
+   Stack_Pool_Address : System.Address with
+      Export,
+      Convention => Ada,
+      External_Name => "__gnat_default_ss_pool";
+
+   Stack_Mark : CRS.Mark;
 
 end System.Secondary_Stack;


### PR DESCRIPTION
The secondary stack is allocated by the binder in the BSS. So there's no need to allocate it somewhere else.