### PR TITLE
Proof of runtime packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ SRC = a-except.adb \
       componolit-runtime-debug.adb \
       componolit-runtime-platform.adb \
       componolit-runtime-exceptions.ads \
+      componolit-runtime-conversions.adb \
       s-exctab.adb \
       s-init.adb \
       s-parame.adb \

--- a/src/lib/componolit-runtime-conversions.adb
+++ b/src/lib/componolit-runtime-conversions.adb
@@ -1,0 +1,31 @@
+
+with Ada.Unchecked_Conversion;
+
+package body Componolit.Runtime.Conversions with
+SPARK_Mode
+is
+
+   function To_Uns_Unchecked is new Ada.Unchecked_Conversion (Int64, Uns64);
+   function To_Int_Unchecked is new Ada.Unchecked_Conversion (Uns64, Int64);
+
+   function To_Int (U : Uns64) return Int64 with
+      SPARK_Mode => Off
+   is
+   begin
+      return To_Int_Unchecked (U);
+   end To_Int;
+
+   function To_Uns (I : Int64) return Uns64 with
+      SPARK_Mode => Off
+   is
+   begin
+      return To_Uns_Unchecked (I);
+   end To_Uns;
+
+   procedure Lemma_Identity (I : Int64; U : Uns64) is null;
+
+   procedure Lemma_Uns_Associativity_Add (X, Y : Int64) is null;
+
+   procedure Lemma_Uns_Associativity_Sub (X, Y : Int64) is null;
+
+end Componolit.Runtime.Conversions;

--- a/src/lib/componolit-runtime-conversions.ads
+++ b/src/lib/componolit-runtime-conversions.ads
@@ -32,15 +32,13 @@ is
                          I < 0 => To_Uns'Result =
                             Uns64'Last - (abs (I) - Uns64'(1)));
 
-   --  pragma Warnings (Off, "procedure ""Lemma_Identity"" is not referenced");
-   --  This lemma is only used to prove its properties.
    procedure Lemma_Identity (I : Int64; U : Uns64) with
+      --  Ghost, --  This should be Ghost but the FSF GNAT crashes here
       Post => I = To_Int (To_Uns (I))
               and U = To_Uns (To_Int (U));
-   --  pragma Warnings (On, "procedure ""Lemma_Identity"" is not referenced");
 
    procedure Lemma_Uns_Associativity_Add (X, Y : Int64) with
-      Ghost,
+      --  Ghost, --  This should be Ghost but the FSF GNAT crashes here
       Pre      => (if X < 0 and Y <= 0 then Int64'First - X < Y)
                   and (if X >= 0 and Y >= 0 then Int64'Last - X >= Y),
       Post     => X + Y = To_Int (To_Uns (X) + To_Uns (Y)),
@@ -48,7 +46,7 @@ is
                    "addition in 2 complement is associative");
 
    procedure Lemma_Uns_Associativity_Sub (X, Y : Int64) with
-      Ghost,
+      --  Ghost, --  This should be Ghost but the FSF GNAT crashes here
       Pre      => (if X >= 0 and Y <= 0 then Y > Int64'First
                       and then Int64'Last - X >= abs (Y))
                    and (if X < 0 and Y > 0 then Y < Int64'First - X),

--- a/src/lib/componolit-runtime-conversions.ads
+++ b/src/lib/componolit-runtime-conversions.ads
@@ -1,0 +1,59 @@
+
+with Interfaces;
+
+package Componolit.Runtime.Conversions with
+SPARK_Mode
+is
+   pragma Pure;
+
+   use type Interfaces.Integer_64;
+   use type Interfaces.Unsigned_64;
+
+   subtype Int64 is Interfaces.Integer_64;
+   subtype Uns64 is Interfaces.Unsigned_64;
+
+   function "abs" (X : Int64) return Uns64 is
+     (if X = Int64'First then 2**63 else Uns64 (Int64'(abs X)));
+   --  Convert absolute value of X to unsigned. Note that we can't just use
+   --  the expression of the Else, because it overflows for X = Int64'First.
+
+   function To_Int (U : Uns64) return Int64 with
+      Inline,
+      Annotate => (GNATprove, Terminating),
+      Contract_Cases => (U <= Uns64 (Int64'Last) =>
+                               To_Int'Result = Int64 (U),
+                         U > Uns64 (Int64'Last) =>
+                               To_Int'Result = -Int64 (Uns64'Last - U) - 1);
+
+   function To_Uns (I : Int64) return Uns64 with
+      Inline,
+      Annotate => (GNATprove, Terminating),
+      Contract_Cases => (I >= 0 => To_Uns'Result = Uns64 (I),
+                         I < 0 => To_Uns'Result =
+                            Uns64'Last - (abs (I) - Uns64'(1)));
+
+   --  pragma Warnings (Off, "procedure ""Lemma_Identity"" is not referenced");
+   --  This lemma is only used to prove its properties.
+   procedure Lemma_Identity (I : Int64; U : Uns64) with
+      Post => I = To_Int (To_Uns (I))
+              and U = To_Uns (To_Int (U));
+   --  pragma Warnings (On, "procedure ""Lemma_Identity"" is not referenced");
+
+   procedure Lemma_Uns_Associativity_Add (X, Y : Int64) with
+      Ghost,
+      Pre      => (if X < 0 and Y <= 0 then Int64'First - X < Y)
+                  and (if X >= 0 and Y >= 0 then Int64'Last - X >= Y),
+      Post     => X + Y = To_Int (To_Uns (X) + To_Uns (Y)),
+      Annotate => (GNATprove, False_Positive, "postcondition",
+                   "addition in 2 complement is associative");
+
+   procedure Lemma_Uns_Associativity_Sub (X, Y : Int64) with
+      Ghost,
+      Pre      => (if X >= 0 and Y <= 0 then Y > Int64'First
+                      and then Int64'Last - X >= abs (Y))
+                   and (if X < 0 and Y > 0 then Y < Int64'First - X),
+      Post     => X - Y = To_Int (To_Uns (X) - To_Uns (Y)),
+      Annotate => (GNATprove, False_Positive, "postcondition",
+                   "subtraction in 2 complement is associative");
+
+end Componolit.Runtime.Conversions;

--- a/src/minimal/a-except.adb
+++ b/src/minimal/a-except.adb
@@ -16,7 +16,9 @@ with Componolit.Runtime.Strings;
 with Componolit.Runtime.Exceptions;
 with System.Standard_Library; use System.Standard_Library;
 
-package body Ada.Exceptions is
+package body Ada.Exceptions with
+   SPARK_Mode => Off
+is
 
    ----------------------------
    -- Raise_Exception_Always --

--- a/src/minimal/a-except.ads
+++ b/src/minimal/a-except.ads
@@ -12,7 +12,11 @@ pragma Compiler_Unit_Warning;
 with System;
 with System.Standard_Library;
 
-package Ada.Exceptions is
+package Ada.Exceptions with
+   SPARK_Mode => Off
+   --  Ada.Exceptions needs access types
+is
+
    pragma Preelaborate;
    --  We make this preelaborable. If we did not do this, then run time units
    --  used by the compiler (e.g. s-soflin.ads) would run into trouble.

--- a/src/minimal/i-c.adb
+++ b/src/minimal/i-c.adb
@@ -1,4 +1,5 @@
-package body Interfaces.C
+package body Interfaces.C with
+   SPARK_Mode
 is
    --  We enforce a body in the spec, as the orignial version in the runtime
    --  has one. If the contrib directory is in our search path, we get an error

--- a/src/minimal/i-c.ads
+++ b/src/minimal/i-c.ads
@@ -15,7 +15,10 @@
 
 with System.Parameters;
 
-package Interfaces.C is
+package Interfaces.C with
+   SPARK_Mode
+is
+
    pragma Pure;
    pragma Elaborate_Body;
 
@@ -64,7 +67,8 @@ package Interfaces.C is
 
    type C_float     is new Float;
    type double      is new Standard.Long_Float;
-   type long_double is new Standard.Long_Long_Float;
+   --  type long_double is new Standard.Long_Long_Float;
+   --  extended precision floating point type is not yet supported
 
    ----------------------------
    -- Characters and Strings --

--- a/src/minimal/s-arit64.adb
+++ b/src/minimal/s-arit64.adb
@@ -198,7 +198,9 @@ is
    procedure Double_Divide
      (X, Y, Z : Int64;
       Q, R    : out Int64;
-      Round   : Boolean)
+      Round   : Boolean) with
+      SPARK_Mode => Off
+      --  TODO: https://github.com/Componolit/ada-runtime/issues/50
    is
       Xu  : constant Uns64 := abs X;
       Yu  : constant Uns64 := abs Y;
@@ -305,7 +307,10 @@ is
    -- Multiply_With_Ovflo_Check --
    -------------------------------
 
-   function Multiply_With_Ovflo_Check (X, Y : Int64) return Int64 is
+   function Multiply_With_Ovflo_Check (X, Y : Int64) return Int64 with
+      SPARK_Mode => Off
+      --  TODO: https://github.com/Componolit/ada-runtime/issues/50
+   is
       Xu  : constant Uns64 := abs X;
       Xhi : constant Uns32 := Hi (Xu);
       Xlo : constant Uns32 := Lo (Xu);
@@ -376,7 +381,9 @@ is
    procedure Scaled_Divide
      (X, Y, Z : Int64;
       Q, R    : out Int64;
-      Round   : Boolean)
+      Round   : Boolean) with
+      SPARK_Mode => Off
+      --  TODO: https://github.com/Componolit/ada-runtime/issues/50
    is
       Xu  : constant Uns64 := abs X;
       Xhi : constant Uns32 := Hi (Xu);

--- a/src/minimal/s-arit64.adb
+++ b/src/minimal/s-arit64.adb
@@ -66,13 +66,22 @@ is
               and U = To_Uns (To_Int (U));
    pragma Warnings (On, "procedure ""Lemma_Identity"" is not referenced");
 
-   procedure Lemma_Uns_Associativity (X, Y : Int64) with
+   procedure Lemma_Uns_Associativity_Add (X, Y : Int64) with
       Ghost,
       Pre      => (if X < 0 and Y <= 0 then Int64'First - X < Y)
                   and (if X >= 0 and Y >= 0 then Int64'Last - X >= Y),
       Post     => X + Y = To_Int (To_Uns (X) + To_Uns (Y)),
       Annotate => (GNATprove, False_Positive, "postcondition",
                    "addition in 2 complement is associative");
+
+   procedure Lemma_Uns_Associativity_Sub (X, Y : Int64) with
+      Ghost,
+      Pre      => (if X >= 0 and Y <= 0 then Y > Int64'First
+                      and then Int64'Last - X >= abs (Y))
+                   and (if X < 0 and Y > 0 then Y < Int64'First - X),
+      Post     => X - Y = To_Int (To_Uns (X) - To_Uns (Y)),
+      Annotate => (GNATprove, False_Positive, "postcondition",
+                   "subtraction in 2 complement is associative");
 
    subtype Uns32 is Unsigned_32;
 
@@ -155,7 +164,9 @@ is
 
    procedure Lemma_Identity (I : Int64; U : Uns64) is null;
 
-   procedure Lemma_Uns_Associativity (X, Y : Int64) is null;
+   procedure Lemma_Uns_Associativity_Add (X, Y : Int64) is null;
+
+   procedure Lemma_Uns_Associativity_Sub (X, Y : Int64) is null;
 
    --------------------------
    -- Add_With_Ovflo_Check --
@@ -165,7 +176,7 @@ is
       R : constant Int64 := To_Int (To_Uns (X) + To_Uns (Y));
 
    begin
-      Lemma_Uns_Associativity (X, Y);
+      Lemma_Uns_Associativity_Add (X, Y);
       if X >= 0 then
          if Y < 0 or else R >= 0 then
             return R;
@@ -620,6 +631,7 @@ is
       R : constant Int64 := To_Int (To_Uns (X) - To_Uns (Y));
 
    begin
+      Lemma_Uns_Associativity_Sub (X, Y);
       if X >= 0 then
          if Y > 0 or else R >= 0 then
             return R;

--- a/src/minimal/s-arit64.adb
+++ b/src/minimal/s-arit64.adb
@@ -31,8 +31,8 @@
 
 with Interfaces; use Interfaces;
 
-with Ada.Unchecked_Conversion;
-
+with Componolit.Runtime.Conversions;
+use Componolit.Runtime.Conversions;
 with Componolit.Runtime.Platform;
 
 package body System.Arith_64 with
@@ -43,46 +43,6 @@ is
    pragma Suppress (Range_Check);
 
    subtype Uns64 is Unsigned_64;
-   function To_Uns_Unchecked is new Ada.Unchecked_Conversion (Int64, Uns64);
-   function To_Int_Unchecked is new Ada.Unchecked_Conversion (Uns64, Int64);
-
-   function To_Int (U : Uns64) return Int64 with
-      Inline,
-      Contract_Cases => (U <= Uns64 (Int64'Last) =>
-                               To_Int'Result = Int64 (U),
-                         U > Uns64 (Int64'Last) =>
-                               To_Int'Result = -Int64 (Uns64'Last - U) - 1);
-
-   function To_Uns (I : Int64) return Uns64 with
-      Inline,
-      Contract_Cases => (I >= 0 => To_Uns'Result = Uns64 (I),
-                         I < 0 => To_Uns'Result =
-                            Uns64'Last - (abs (I) - Uns64'(1)));
-
-   pragma Warnings (Off, "procedure ""Lemma_Identity"" is not referenced");
-   --  This lemma is only used to prove its properties.
-   procedure Lemma_Identity (I : Int64; U : Uns64) with
-      Post => I = To_Int (To_Uns (I))
-              and U = To_Uns (To_Int (U));
-   pragma Warnings (On, "procedure ""Lemma_Identity"" is not referenced");
-
-   procedure Lemma_Uns_Associativity_Add (X, Y : Int64) with
-      Ghost,
-      Pre      => (if X < 0 and Y <= 0 then Int64'First - X < Y)
-                  and (if X >= 0 and Y >= 0 then Int64'Last - X >= Y),
-      Post     => X + Y = To_Int (To_Uns (X) + To_Uns (Y)),
-      Annotate => (GNATprove, False_Positive, "postcondition",
-                   "addition in 2 complement is associative");
-
-   procedure Lemma_Uns_Associativity_Sub (X, Y : Int64) with
-      Ghost,
-      Pre      => (if X >= 0 and Y <= 0 then Y > Int64'First
-                      and then Int64'Last - X >= abs (Y))
-                   and (if X < 0 and Y > 0 then Y < Int64'First - X),
-      Post     => X - Y = To_Int (To_Uns (X) - To_Uns (Y)),
-      Annotate => (GNATprove, False_Positive, "postcondition",
-                   "subtraction in 2 complement is associative");
-
    subtype Uns32 is Unsigned_32;
 
    -----------------------
@@ -147,26 +107,6 @@ is
    procedure Raise_Error with Inline;
    pragma No_Return (Raise_Error);
    --  Raise constraint error with appropriate message
-
-   function To_Int (U : Uns64) return Int64 with
-      SPARK_Mode => Off
-   is
-   begin
-      return To_Int_Unchecked (U);
-   end To_Int;
-
-   function To_Uns (I : Int64) return Uns64 with
-      SPARK_Mode => Off
-   is
-   begin
-      return To_Uns_Unchecked (I);
-   end To_Uns;
-
-   procedure Lemma_Identity (I : Int64; U : Uns64) is null;
-
-   procedure Lemma_Uns_Associativity_Add (X, Y : Int64) is null;
-
-   procedure Lemma_Uns_Associativity_Sub (X, Y : Int64) is null;
 
    --------------------------
    -- Add_With_Ovflo_Check --

--- a/src/minimal/s-arit64.ads
+++ b/src/minimal/s-arit64.ads
@@ -45,8 +45,12 @@ is
    pragma Pure;
 
    subtype Int64 is Interfaces.Integer_64;
+   use type Interfaces.Integer_64;
 
-   function Add_With_Ovflo_Check (X, Y : Int64) return Int64;
+   function Add_With_Ovflo_Check (X, Y : Int64) return Int64 with
+      Pre  => (if X < 0 and Y <= 0 then Int64'First - X < Y)
+              and (if X >= 0 and Y >= 0 then Int64'Last - X >= Y),
+      Post => Add_With_Ovflo_Check'Result = X + Y;
    --  Raises Constraint_Error if sum of operands overflows 64 bits,
    --  otherwise returns the 64-bit signed integer sum.
 

--- a/src/minimal/s-arit64.ads
+++ b/src/minimal/s-arit64.ads
@@ -54,7 +54,11 @@ is
    --  Raises Constraint_Error if sum of operands overflows 64 bits,
    --  otherwise returns the 64-bit signed integer sum.
 
-   function Subtract_With_Ovflo_Check (X, Y : Int64) return Int64;
+   function Subtract_With_Ovflo_Check (X, Y : Int64) return Int64 with
+      Pre  => (if X >= 0 and Y <= 0 then Y > Int64'First
+                  and then Int64'Last - X >= abs (Y))
+              and (if X < 0 and Y > 0 then Y < Int64'First - X),
+      Post => Subtract_With_Ovflo_Check'Result = X - Y;
    --  Raises Constraint_Error if difference of operands overflows 64
    --  bits, otherwise returns the 64-bit signed integer difference.
 

--- a/src/minimal/s-arit64.ads
+++ b/src/minimal/s-arit64.ads
@@ -38,7 +38,10 @@ pragma Restrictions (No_Elaboration_Code);
 
 with Interfaces;
 
-package System.Arith_64 is
+package System.Arith_64 with
+   SPARK_Mode
+is
+
    pragma Pure;
 
    subtype Int64 is Interfaces.Integer_64;

--- a/src/minimal/s-exctab.adb
+++ b/src/minimal/s-exctab.adb
@@ -9,7 +9,10 @@
 
 with Componolit.Runtime.Debug;
 
-package body System.Exception_Table is
+package body System.Exception_Table with
+   SPARK_Mode => Off
+   --  Exception_Data_Ptr is an access type
+is
 
    use System.Standard_Library;
 

--- a/src/minimal/s-exctab.ads
+++ b/src/minimal/s-exctab.ads
@@ -9,7 +9,9 @@
 
 with System.Standard_Library;
 
-package System.Exception_Table is
+package System.Exception_Table with
+   SPARK_Mode => Off
+is
 
    package SSL renames System.Standard_Library;
 

--- a/src/minimal/s-parame.adb
+++ b/src/minimal/s-parame.adb
@@ -1,5 +1,4 @@
-package body System.Parameters with
-   SPARK_Mode => Off
+package body System.Parameters
 is
    --  We enforce a body in the spec, as the orignial version in the runtime
    --  has one. If the contrib directory is in our search path, we get an error

--- a/src/minimal/s-parame.adb
+++ b/src/minimal/s-parame.adb
@@ -1,4 +1,5 @@
-package body System.Parameters
+package body System.Parameters with
+   SPARK_Mode => Off
 is
    --  We enforce a body in the spec, as the orignial version in the runtime
    --  has one. If the contrib directory is in our search path, we get an error

--- a/src/minimal/s-parame.ads
+++ b/src/minimal/s-parame.ads
@@ -7,7 +7,11 @@
 --  additional permissions described in the GCC Runtime Library Exception,
 --  version 3.1, as published by the Free Software Foundation.
 
-package System.Parameters is
+package System.Parameters with
+   SPARK_Mode => Off
+   --  Attribute 'Address_Size is not allowed in SPARK
+is
+
    pragma Pure;
    pragma Elaborate_Body;
 

--- a/src/minimal/s-parame.ads
+++ b/src/minimal/s-parame.ads
@@ -7,9 +7,7 @@
 --  additional permissions described in the GCC Runtime Library Exception,
 --  version 3.1, as published by the Free Software Foundation.
 
-package System.Parameters with
-   SPARK_Mode => Off
-   --  Attribute 'Address_Size is not allowed in SPARK
+package System.Parameters
 is
 
    pragma Pure;

--- a/src/minimal/s-soflin.adb
+++ b/src/minimal/s-soflin.adb
@@ -9,7 +9,9 @@
 
 with Componolit.Runtime.Debug;
 
-package body System.Soft_Links is
+package body System.Soft_Links with
+   SPARK_Mode => Off
+is
 
    function Get_Current_Excep_NT return EOA is
    begin

--- a/src/minimal/s-soflin.ads
+++ b/src/minimal/s-soflin.ads
@@ -9,7 +9,12 @@
 
 with Ada.Exceptions;
 
-package System.Soft_Links is
+package System.Soft_Links with
+   SPARK_Mode => Off
+   --  Use of unallowed access types
+   --  pragma Favor_Top_Level is not yet supported
+is
+
    pragma Preelaborate;
 
    subtype EOA is Ada.Exceptions.Exception_Occurrence_Access;

--- a/src/minimal/s-stalib.adb
+++ b/src/minimal/s-stalib.adb
@@ -1,4 +1,5 @@
-package body System.Standard_Library
+package body System.Standard_Library with
+   SPARK_Mode => Off
 is
    --  We enforce a body in the spec, as the orignial version in the runtime
    --  has one. If the contrib directory is in our search path, we get an error

--- a/src/minimal/s-stalib.ads
+++ b/src/minimal/s-stalib.ads
@@ -10,7 +10,11 @@
 
 with Ada.Unchecked_Conversion;
 
-package System.Standard_Library is
+package System.Standard_Library with
+   SPARK_Mode => Off
+   --  Use of access types
+is
+
    pragma Preelaborate;
    pragma Elaborate_Body;
 

--- a/src/minimal/s-stoele.adb
+++ b/src/minimal/s-stoele.adb
@@ -34,7 +34,9 @@ pragma Compiler_Unit_Warning;
 with Ada.Unchecked_Conversion;
 with Componolit.Runtime.Platform;
 
-package body System.Storage_Elements is
+package body System.Storage_Elements with
+   SPARK_Mode
+is
 
    pragma Suppress (All_Checks);
 

--- a/src/minimal/s-stoele.ads
+++ b/src/minimal/s-stoele.ads
@@ -39,7 +39,10 @@
 
 pragma Compiler_Unit_Warning;
 
-package System.Storage_Elements is
+package System.Storage_Elements with
+   SPARK_Mode
+is
+
    pragma Pure;
    --  Note that we take advantage of the implementation permission to make
    --  this unit Pure instead of Preelaborable; see RM 13.7.1(15). In Ada 2005,
@@ -64,8 +67,10 @@ package System.Storage_Elements is
    type Storage_Element is mod 2 ** Storage_Unit;
    for Storage_Element'Size use Storage_Unit;
 
+   pragma Warnings (Off, "pragma ""Universal_Aliasing"" ignored");
    pragma Universal_Aliasing (Storage_Element);
    --  This type is used by the expander to implement aggregate copy
+   pragma Warnings (On, "pragma ""Universal_Aliasing"" ignored");
 
    type Storage_Array is
      array (Storage_Offset range <>) of aliased Storage_Element;
@@ -95,7 +100,8 @@ package System.Storage_Elements is
 
    function "mod"
      (Left  : Address;
-      Right : Storage_Offset) return  Storage_Offset;
+      Right : Storage_Offset) return  Storage_Offset with
+      Pre => Right > 0;
    pragma Convention (Intrinsic, "mod");
    pragma Inline_Always ("mod");
    pragma Pure_Function ("mod");

--- a/tests/muen.sh
+++ b/tests/muen.sh
@@ -3,7 +3,7 @@
 cd /muen
 git reset --hard
 git fetch --all
-git checkout d78c4ac4cdbf66dc21eda82b315414eba783adb6
+git checkout 82250b20144be95bc0af4ba266035c24042acccf
 rm -r components/spark_runtime/src
 ln -sf /app components/spark_runtime/src
 make -j$(nproc)

--- a/tests/unit/componolit-runtime-conversions-tests.adb
+++ b/tests/unit/componolit-runtime-conversions-tests.adb
@@ -1,0 +1,136 @@
+with AUnit.Assertions;
+
+package body Componolit.Runtime.Conversions.Tests is
+
+   procedure Test_Uns (T : in out Aunit.Test_Cases.Test_Case'Class)
+   is
+      I_First : constant Uns64 := Uns64 (Int64'Last) + 1;
+   begin
+      Aunit.Assertions.Assert (Uns64'Last'Img, To_Uns (-1)'Img, "-1 is not Uns64'Last");
+      AUnit.Assertions.Assert (Uns64'First'Img, To_Uns (0)'Img, "0 is not Uns64'First");
+      Aunit.Assertions.Assert (Uns64 (Int64'Last)'Img, To_Uns (Int64'Last)'Img, "Int64'Last is not Int64'Last");
+      AUnit.Assertions.Assert (I_First'Img, To_Uns (Int64'First)'Img, "Int64'First is not Int64'Last + 1");
+      Aunit.Assertions.Assert (" 100", To_Uns (100)'Img, "100 is not 100");
+      Aunit.Assertions.Assert (" 18446744073709551516", To_Uns (-100)'Img, "100 is not 18446744073709551516");
+   end Test_Uns;
+   
+   procedure Test_Int (T : in out AUnit.Test_Cases.Test_Case'Class)
+   is
+      I_First  : constant Uns64 := Uns64 (Int64'Last) + 1;
+   begin
+      AUnit.Assertions.Assert ("-1", To_Int (Uns64'Last)'Img, "Uns64'Last is not -1");
+      AUnit.Assertions.Assert (" 0", To_Int (Uns64'First)'Img, "0 is not Uns64'First");
+      AUnit.Assertions.Assert (Int64'First'Img, To_Int (I_First)'Img, "Uns64 (Int64'First) is not Int64'First");
+      AUnit.Assertions.Assert (Int64'Last'Img, To_Int (Uns64 (Int64'Last))'Img, "Int64'First + 1 is not Int64'Last");
+      AUnit.Assertions.Assert ("-100", To_Int (18446744073709551516)'Img, "18446744073709551516 is not -100");
+      AUnit.Assertions.Assert (" 100", To_Int (100)'Img, "100 is not 100");
+   end Test_Int;
+   
+   procedure Test_Identity (T : in out AUnit.Test_Cases.Test_Case'Class)
+   is
+   begin
+      for I in Int64 range Int64'First .. Int64'First + 20 loop
+         AUnit.Assertions.Assert (I'Img, To_Int (To_Uns (I))'Img, "Int64'First .. Int64'First + 20");
+      end loop;
+      for I in Int64 range -10 .. 10 loop
+         Aunit.Assertions.Assert (I'Img, To_Int (To_Uns (I))'Img, "-10 .. 10");
+      end loop;
+      for I in Int64 range Int64'Last - 20 .. Int64'Last loop
+         AUnit.Assertions.Assert (I'Img, To_Int (To_Uns (I))'Img, "Int64'Last - 20 .. Int64'Last");
+      end loop;
+      for U in Uns64 range Uns64'First .. Uns64'First + 20 loop
+         Aunit.Assertions.Assert (U'Img, To_Uns (To_Int (U))'Img, "Uns64'First .. Uns64'First + 20");
+      end loop;
+      for U in Uns64 range Uns64 (Int64'Last) - 10 .. Uns64 (Int64'Last) + 10 loop
+         AUnit.Assertions.Assert (U'Img, To_Uns (To_Int (U))'Img, "Uns64 (Int64'Last) - 10 .. Uns64 (Int64'Last) + 10");
+      end loop;
+      for U in Uns64 range Uns64'Last - 10 .. Uns64'Last loop
+         AUnit.Assertions.Assert (U'Img, To_Uns (To_Int (U))'Img, "Uns64'Last - 10 .. Uns64'Last");
+      end loop;
+   end Test_Identity;
+   
+   procedure Test_Lemma_Add (T : in out AUnit.Test_Cases.Test_Case'Class)
+   is
+      K          : Int64;
+      Test_First : Boolean := False;
+      Test_Last  : Boolean := False;
+   begin
+      for I in Int64 range -10 .. 10 loop
+         for J in Int64 range Int64'First + 10 .. Int64'First + 20 loop
+            K := I + J;
+            if K = Int64'First then
+               Test_First := True;
+            end if;
+            AUnit.Assertions.Assert (K'Img, To_Int (To_Uns (I) + To_Uns (J))'Img, "Int64'First + 10 .. Int64'First + 20");
+         end loop;
+         for J in Int64 range -10 .. 10 loop
+            K := I + J;
+            AUnit.Assertions.Assert (K'Img, To_Int (To_Uns (I) + To_Uns (J))'Img, "-10 .. 10");
+         end loop;
+         for J in Int64 range Int64'Last - 20 .. Int64'Last - 10 loop
+            K := I + J;
+            if K = Int64'Last then
+               Test_Last := True;
+            end if;
+            Aunit.Assertions.Assert (K'Img, To_Int (To_Uns (I) + To_Uns (J))'Img, "Int64'Last - 20 .. Int64'Last + 10");
+         end loop;
+      end loop;
+      AUnit.Assertions.Assert (Test_First, "Int64'First result not tested");
+      AUnit.Assertions.Assert (Test_Last, "Int64'Last result not tested");
+   end Test_Lemma_Add;
+   
+   procedure Test_Lemma_Sub (T : in out AUnit.Test_Cases.Test_Case'Class)
+   is
+      K          : Int64;
+      Test_First : Boolean := False;
+      Test_Last  : Boolean := False;
+   begin
+      for I in Int64 range -10 .. 10 loop
+         for J in Int64 range Int64'First + 10 .. Int64'First + 20 loop
+            K := J - I;
+            if K = Int64'First then
+               Test_First := True;
+            end if;
+            AUnit.Assertions.Assert (K'Img, To_Int (To_Uns (J) - To_Uns (I))'Img, "Int64'First + 10 .. Int64'First + 20");
+         end loop;
+         for J in Int64 range -10 .. 10 loop
+            K := J - I;
+            AUnit.Assertions.Assert (K'Img, To_Int (To_Uns (J) - To_Uns (I))'Img, "-10 .. 10");
+         end loop;
+         for J in Int64 range Int64'Last - 20 .. Int64'Last - 10 loop
+            K := J - I;
+            if K = Int64'Last then
+               Test_Last := True;
+            end if;
+            Aunit.Assertions.Assert (K'Img, To_Int (To_Uns (J) - To_Uns (I))'Img, "Int64'Last - 20 .. Int64'Last + 10");
+         end loop;
+      end loop;
+      AUnit.Assertions.Assert (Test_First, "Int64'First result not tested");
+      AUnit.Assertions.Assert (Test_Last, "Int64'Last result not tested");
+   end Test_Lemma_Sub;
+   
+   --------------------
+   -- Register_Tests --
+   --------------------
+
+   procedure Register_Tests (T : in out Test_Case) is
+      use AUnit.Test_Cases.Registration;
+   begin
+      Register_Routine (T, Test_Uns'Access, "Test To_Uns");
+      Register_Routine (T, Test_Int'Access, "Test To_Int");
+      Register_Routine (T, Test_Identity'Access, "Test Identity");
+      Register_Routine (T, Test_Lemma_Add'Access, "Test Add Lemma");
+      Register_Routine (T, Test_Lemma_Sub'Access, "Test Sub Lemma");
+   end Register_Tests;
+
+   ----------
+   -- Name --
+   ----------
+
+   function Name (T : Test_Case) return Aunit.Message_String is
+   begin
+      return Aunit.Format ("Componolit.Runtime.Conversions");
+   end Name;
+
+
+end Componolit.Runtime.Conversions.Tests;

--- a/tests/unit/componolit-runtime-conversions-tests.ads
+++ b/tests/unit/componolit-runtime-conversions-tests.ads
@@ -1,0 +1,13 @@
+
+with Aunit;
+with Aunit.Test_Cases;
+
+package Componolit.Runtime.Conversions.Tests is
+
+   type Test_Case is new Aunit.Test_Cases.Test_Case with null record;
+
+   procedure Register_Tests (T : in out Test_Case);
+
+   function Name (T : Test_Case) return Aunit.Message_String;
+
+end Componolit.Runtime.Conversions.Tests;

--- a/tests/unit/rts_suite.adb
+++ b/tests/unit/rts_suite.adb
@@ -1,11 +1,13 @@
 with Componolit.Runtime.Strings.Tests;
+with Componolit.Runtime.Conversions.Tests;
 
 package body Rts_Suite is
    use Aunit.Test_Suites;
 
    Result : aliased Test_Suite;
 
-   Strings_Case : aliased Componolit.Runtime.Strings.Tests.Test_Case;
+   Strings_Case     : aliased Componolit.Runtime.Strings.Tests.Test_Case;
+   Conversions_Case : aliased Componolit.Runtime.Conversions.Tests.Test_Case;
 
    -----------
    -- Suite --
@@ -14,6 +16,7 @@ package body Rts_Suite is
    function Suite return AUnit.Test_Suites.Access_Test_Suite is
    begin
       Result.Add_Test (Strings_Case'Access);
+      Result.Add_Test (Conversions_Case'Access);
       return Result'Access;
    end Suite;
 


### PR DESCRIPTION
Prove the runtime packages in the minimal runtime. For those packages that require code that is not SPARK compatible SPARK has been turned off with a comment. `System.Parameters` cannot be SPARK but SPARK also cannot be turned off explicitly as its types could not be used in SPARK code then. In `Interfaces.C` the long double has been disabled as it is not supported in SPARK.
The `System.Arith64` has been proven for `Add_With_Ovflo_Check` and `Subtract_With_Ovflo_Check` for the absence of runtime errors. The missing functions and the two unproven lemmas are handled in #50. Since the properties of the conversion functions rest on assumptions about the binary integer representation they have been moved to a separate package to support unit tests.