### PR TITLE
remove separate libposix_rts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ SRC = a-except.adb \
       argv.c \
       exit.c \
       init.c \
+      posix_common.c \
+      posix_minimal.c \
+      componolit_runtime.h \
+      ada_exceptions.h \
+      gnat_helpers.h
 
 SRC := $(sort $(SRC) $(patsubst %.adb, %.ads, $(filter %.adb, $(SRC))))
 
@@ -54,13 +59,11 @@ $(OBJ_DIR)/adainclude/%: src/lib/%
 $(OBJ_DIR)/adainclude/%: contrib/gcc-8.3.0/%
 	$(VERBOSE)cp -a $< $@
 
-platform: $(OBJ_DIR)/lib/libposix_rts.a
+$(OBJ_DIR)/adainclude/%: platform/%
+	$(VERBOSE)cp -a $< $@
 
-$(OBJ_DIR)/lib/libposix_rts.a: $(OBJ_DIR)/posix_common.o $(OBJ_DIR)/posix_minimal.o
-	$(VERBOSE)ar rcs $@ $^
-
-$(OBJ_DIR)/%.o: platform/linux/%.c
-	$(VERBOSE)gcc -Iplatform -c -o $@ $<
+$(OBJ_DIR)/adainclude/%: platform/linux/%
+	$(VERBOSE)cp -a $< $@
 
 clean: clean_test
 	$(VERBOSE)rm -rf $(OBJ_DIR)
@@ -76,7 +79,7 @@ $(UNIT_DIR)/test:
 	@echo "UNITTEST $(dir $@)"
 	$(VERBOSE)cd $(dir $@) && gprbuild -q -P test && ./test
 
-test: runtime platform clean_test $(TEST_BINS) $(UNIT_DIR)/test
+test: runtime clean_test $(TEST_BINS) $(UNIT_DIR)/test
 
 REPORT ?= fail
 

--- a/rts.gpr
+++ b/rts.gpr
@@ -13,6 +13,7 @@ library project rts is
 
    package Compiler is
       for Default_Switches ("Ada") use ("-gnatg", "-fPIC");
+      for Default_Switches ("C") use ("-fPIC");
    end Compiler;
 
    package Naming is

--- a/tests/system/arit64/test.gpr
+++ b/tests/system/arit64/test.gpr
@@ -7,7 +7,7 @@ project Test is
    end Binder;
 
    package Linker is
-      for Required_Switches use ("-L../../../obj/lib", "-lposix_rts", "-lpthread");
+      for Required_Switches use ("-lpthread");
    end Linker;
 
 end Test;

--- a/tests/system/exception/test.gpr
+++ b/tests/system/exception/test.gpr
@@ -7,7 +7,7 @@ project Test is
    end Binder;
 
    package Linker is
-      for Required_Switches use ("-L../../../obj/lib", "-lposix_rts", "-lpthread");
+      for Required_Switches use ("-lpthread");
    end Linker;
 
 end Test;

--- a/tests/system/minimal/test.gpr
+++ b/tests/system/minimal/test.gpr
@@ -7,7 +7,7 @@ project Test is
    end Binder;
 
    package Linker is
-      for Required_Switches use ("-L../../../obj/lib", "-lposix_rts", "-lpthread");
+      for Required_Switches use ("-lpthread");
    end Linker;
 
 end Test;

--- a/tests/system/secondary-stack/test.gpr
+++ b/tests/system/secondary-stack/test.gpr
@@ -7,7 +7,7 @@ project Test is
    end Binder;
 
    package Linker is
-      for Required_Switches use ("-L../../../obj/lib", "-lposix_rts", "-lpthread");
+      for Required_Switches use ("-lpthread");
    end Linker;
 
 end Test;

--- a/tests/system/stand-alone-library/test.gpr
+++ b/tests/system/stand-alone-library/test.gpr
@@ -10,7 +10,7 @@ project Test is
    end Binder;
 
    package Linker is
-      for Required_Switches use ("-L../../../obj/adalib", "-lgnat", "-L../../../obj/lib", "-lposix_rts", "-lpthread");
+      for Required_Switches use ("-L../../../obj/adalib", "-lgnat", "-lpthread");
    end Linker;
 
 end Test;


### PR DESCRIPTION
Since linking the libposix_rts separately to the libgnat into applications is cumbersome at some times and there's no other reason to keep it separate I removed this extra step and build a complete libgnat. In case that there's any other platform that can use the same build system but is not compatible with out posix implementation this can still be managed by source code selection at compile time.