### PR TITLE
Fix GPIO proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,7 @@ jobs:
         steps:
             - uses: actions/checkout@v1
             - name: GNAT Community 2019
-              run: docker run -v $PWD:/app componolit/ci:gnat-community-2019 /bin/sh -c "/app/tests/posix.sh"
-    gnat_community_2019_arm:
-        name: gnat-community-2019-arm
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v1
+              run: docker run -v $PWD:/app componolit/ci:gnat-community-2019-arm /bin/sh -c "/app/tests/posix.sh"
             - name: GNAT Community 2019 ARM
               run: docker run -v $PWD:/app componolit/ci:gnat-community-2019-arm /bin/sh -c "/app/tests/arm.sh"
     genode:

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ REPORT ?= fail
 
 proof:
 	$(VERBOSE)gnatprove --level=3 --checks-as-errors -j0 -Psrc/componolit_runtime.gpr -XOBJECT_DIR=$(OBJ_DIR) --info --report=$(REPORT)
+	$(VERBOSE)gnatprove --level=3 --checks-as-errors -j0 -Pplatform/stm32f0/drivers.gpr -XOBJECT_DIR=$(OBJ_DIR) --info --report=$(REPORT)
 
 clean: clean_test
 	make -C build/posix clean

--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,12 @@ test: posix clean_test $(TEST_BINS) $(UNIT_DIR)/test
 
 REPORT ?= fail
 
-proof:
+proof: stm32f0 nrf52
 	$(VERBOSE)gnatprove --level=3 --checks-as-errors -j0 -Psrc/componolit_runtime.gpr -XOBJECT_DIR=$(OBJ_DIR) --info --report=$(REPORT)
 	$(VERBOSE)gnatprove --level=4 --checks-as-errors -j0 -Pplatform/stm32f0/drivers.gpr -XOBJECT_DIR=$(OBJ_DIR) --info --report=$(REPORT)
 	$(VERBOSE)gnatprove --level=3 --checks-as-errors -j0 -Pplatform/nrf52/drivers.gpr -XOBJECT_DIR=$(OBJ_DIR) --info --report=$(REPORT)
+	$(VERBOSE)gnatprove --level=3 --checks-as-errors -j0 -Ptests/platform/stm32f0/test.gpr -XOBJECT_DIR=$(OBJ_DIR) --info --report=$(REPORT)
+	$(VERBOSE)gnatprove --level=3 --checks-as-errors -j0 -Ptests/platform/nrf52/test.gpr -XOBJECT_DIR=$(OBJ_DIR) --info --report=$(REPORT)
 
 clean: clean_test
 	make -C build/posix clean

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,8 @@ REPORT ?= fail
 
 proof:
 	$(VERBOSE)gnatprove --level=3 --checks-as-errors -j0 -Psrc/componolit_runtime.gpr -XOBJECT_DIR=$(OBJ_DIR) --info --report=$(REPORT)
-	$(VERBOSE)gnatprove --level=3 --checks-as-errors -j0 -Pplatform/stm32f0/drivers.gpr -XOBJECT_DIR=$(OBJ_DIR) --info --report=$(REPORT)
+	$(VERBOSE)gnatprove --level=4 --checks-as-errors -j0 -Pplatform/stm32f0/drivers.gpr -XOBJECT_DIR=$(OBJ_DIR) --info --report=$(REPORT)
+	$(VERBOSE)gnatprove --level=3 --checks-as-errors -j0 -Pplatform/nrf52/drivers.gpr -XOBJECT_DIR=$(OBJ_DIR) --info --report=$(REPORT)
 
 clean: clean_test
 	make -C build/posix clean

--- a/platform/nrf52/drivers/componolit-runtime-drivers-gpio.adb
+++ b/platform/nrf52/drivers/componolit-runtime-drivers-gpio.adb
@@ -1,7 +1,7 @@
 
 package body Componolit.Runtime.Drivers.GPIO with
    SPARK_Mode,
-   Refined_State => (Shadow_GPIO_Configuration => Shadow_DIR_Reg,
+   Refined_State => (Shadow_GPIO_Configuration => (Shadow_DIR_Reg, Pins),
                      GPIO_Configuration        => DIR_Reg,
                      GPIO_State                => (OUTSET_Reg,
                                                    OUTCLR_Reg,
@@ -45,6 +45,12 @@ is
 
    Shadow_DIR_Reg : Pin_Modes := DIR_Reg;
 
+   Pins : Configured_Pins := (others => False);
+
+   function Pins_Configured return Configured_Pins is (Pins);
+
+   function Configured (P : Pin) return Boolean is (Pins (P));
+
    function Convert (P : Pin_Value) return Value is
       (case P is
          when 0 => Low,
@@ -55,6 +61,7 @@ is
    begin
       Shadow_DIR_Reg (P) := M;
       DIR_Reg            := Shadow_DIR_Reg;
+      Pins (P)           := True;
    end Configure;
 
    function Pin_Mode (P : Pin) return Mode is

--- a/platform/nrf52/drivers/componolit-runtime-drivers-gpio.adb
+++ b/platform/nrf52/drivers/componolit-runtime-drivers-gpio.adb
@@ -86,4 +86,6 @@ is
       end case;
    end Read;
 
+   function Proof_Modes return Pin_Modes is (Shadow_DIR_Reg);
+
 end Componolit.Runtime.Drivers.GPIO;

--- a/platform/nrf52/drivers/componolit-runtime-drivers-gpio.ads
+++ b/platform/nrf52/drivers/componolit-runtime-drivers-gpio.ads
@@ -25,29 +25,50 @@ is
       Size => 32,
       Pack;
 
+   type Configured_Pins is array (Pin'Range) of Boolean;
+
+   function Pins_Configured return Configured_Pins with
+      Ghost,
+      Global => (Input => Shadow_GPIO_Configuration);
+
+   function Configured (P : Pin) return Boolean with
+      Ghost,
+      Post   => Configured'Result = Pins_Configured (P),
+      Global => (Input => Shadow_GPIO_Configuration);
+
    function Proof_Modes return Pin_Modes with
       Ghost,
       Global => (Input => Shadow_GPIO_Configuration);
 
    procedure Configure (P : Pin; M : Mode) with
-      Post   => Pin_Mode (P) = M
+      Post   => Configured (P)
+                and then Pin_Mode (P) = M
                 and then (for all Pn in Pin =>
-                   (if Pn /= P then Proof_Modes (Pn) = Proof_Modes'Old (Pn))),
+                             (if Pn /= P then Proof_Modes (Pn) =
+                                    Proof_Modes'Old (Pn)))
+                and then (for all Pn in Pin =>
+                             (if Pn /= P then Pins_Configured (Pn) =
+                                    Pins_Configured'Old (Pn))),
       Global => (In_Out => Shadow_GPIO_Configuration,
                  Output => GPIO_Configuration);
 
    function Pin_Mode (P : Pin) return Mode with
+      Pre    => Configured (P),
       Post   => Pin_Mode'Result = Proof_Modes (P),
       Global => (Input => Shadow_GPIO_Configuration),
       Ghost;
 
    procedure Write (P : Pin; V : Value) with
-      Pre    => Pin_Mode (P) = Port_Out,
+      Pre    => Configured (P)
+                and then Pin_Mode (P) = Port_Out,
       Global => (In_Out    => GPIO_State,
                  Proof_In  => Shadow_GPIO_Configuration);
 
    procedure Read (P : Pin; V : out Value) with
-      Global => (Input  => (GPIO_Configuration, GPIO_State));
+      Pre    => Configured (P)
+                and then Pin_Mode (P) in Port_In | Port_Out,
+      Global => (Input    => (GPIO_Configuration, GPIO_State),
+                 Proof_In => Shadow_GPIO_Configuration);
 
 private
 

--- a/platform/stm32f0/drivers/componolit-runtime-drivers-gpio.adb
+++ b/platform/stm32f0/drivers/componolit-runtime-drivers-gpio.adb
@@ -3,7 +3,7 @@ package body Componolit.Runtime.Drivers.GPIO with
    Refined_State => (Configuration_State        => Config_Registers,
                      GPIO_State                 => IO_Registers,
                      Shadow_Configuration_State => (Shadow_Config,
-                                                    Modes))
+                                                    Modes, Pins))
 is
 
    use type SSE.Integer_Address;
@@ -45,6 +45,8 @@ is
 
    Modes : Proof_Pin_Mode := (others => Port_In) with Ghost;
 
+   Pins : Configured_Pins := (others => False) with Ghost;
+
    procedure Unfold_Valid with
       Ghost,
       Pre  => (for all Pn in Pin => Valid (Pn)),
@@ -85,6 +87,7 @@ is
                                    Shadow_Config (Bank_Select (Q))
                                 (Pin_Offset (Q)));
       end loop;
+      Pins := (others => False);
    end Initialize;
 
    procedure Configure (P : Pin;
@@ -105,6 +108,7 @@ is
       Config_Registers (Bank_Select (P)).Port_Mode :=
          Shadow_Config (Bank_Select (P));
       Modes (P) := Shadow_Config (Bank_Select (P)) (Pin_Offset (P));
+      Pins (P)  := True;
    end Configure;
 
    function Pin_Mode (P : Pin) return Mode is
@@ -153,5 +157,9 @@ is
    function Valid (P : Pin) return Boolean is
       (Shadow_Config (Bank_Select (P))
        (Pin_Offset (P)) = Modes (P));
+
+   function Pins_Configured return Configured_Pins is (Pins);
+
+   function Configured (P : Pin) return Boolean is (Pins (P));
 
 end Componolit.Runtime.Drivers.GPIO;

--- a/platform/stm32f0/drivers/componolit-runtime-drivers-gpio.ads
+++ b/platform/stm32f0/drivers/componolit-runtime-drivers-gpio.ads
@@ -1,3 +1,4 @@
+with Componolit.Runtime.Drivers.RCC;
 
 package Componolit.Runtime.Drivers.GPIO with
    SPARK_Mode,
@@ -47,9 +48,10 @@ is
       Global => (Input => Shadow_Configuration_State);
 
    procedure Initialize with
-      Ghost,
       Post   => (for all P in Pin => Valid (P)),
-      Global => (In_Out => Shadow_Configuration_State);
+      Global => (Input  => Configuration_State,
+                 In_Out => (Shadow_Configuration_State,
+                            RCC.RCC_State));
 
    procedure Configure (P : Pin;
                         M : Mode;
@@ -60,8 +62,8 @@ is
                              (if Pn /= P then Pin_Modes (Pn) =
                                     Pin_Modes'Old (Pn)))
                 and then (for all Pn in Pin => Valid (Pn)),
-      Global => (In_Out => Shadow_Configuration_State,
-                 Output => Configuration_State);
+      Global => (In_Out => (Shadow_Configuration_State,
+                            Configuration_State));
 
    function Pin_Mode (P : Pin) return Mode with
       Pre    => Valid (P),
@@ -159,6 +161,8 @@ private
    type Configuration is array (Bank_Id'Range) of Bank_Config with
       Size => 6 * 1024 * 8,
       Pack;
+
+   type Pull_Config is array (Bank_Id'Range) of Mode_Register;
 
    type Input_Output is array (Bank_Id'Range) of Bank_IO with
       Size => 6 * 1024 * 8,

--- a/platform/stm32f0/drivers/componolit-runtime-drivers-rcc.ads
+++ b/platform/stm32f0/drivers/componolit-runtime-drivers-rcc.ads
@@ -5,7 +5,7 @@ package Componolit.Runtime.Drivers.RCC with
    Initializes    => RCC_State
 is
 
-   type Clock is (IOPA, IOPB, IOPC, IOPD);
+   type Clock is (IOPA, IOPB, IOPC, IOPD, IOPF);
 
    procedure Set (Clk    : Clock;
                   Enable : Boolean) with
@@ -19,14 +19,15 @@ private
    RCC_Base      : constant SSE.Integer_Address := 16#4002_1000#;
    AHB_EN_Offset : constant SSE.Integer_Address := 16#14#;
 
-   for Clock use (IOPA => 17, IOPB => 18, IOPC => 19, IOPD => 20);
+   for Clock use (IOPA => 17, IOPB => 18, IOPC => 19, IOPD => 20, IOPF => 22);
 
    function Clock_Bit (C : Clock) return Natural is
       (case C is
           when IOPA => 17,
           when IOPB => 18,
           when IOPC => 19,
-          when IOPD => 20);
+          when IOPD => 20,
+          when IOPF => 22);
 
    type Bit is range 0 .. 1 with
       Size => 1;

--- a/tests/platform/nrf52/main.adb
+++ b/tests/platform/nrf52/main.adb
@@ -1,6 +1,14 @@
+with Componolit.Runtime.Drivers.GPIO;
 
-procedure Main
+procedure Main with
+   SPARK_Mode
 is
+   package GPIO renames Componolit.Runtime.Drivers.GPIO;
+   use type GPIO.Mode;
 begin
-   null;
+   GPIO.Configure (15, GPIO.Port_In);
+   pragma Assert (GPIO.Pin_Mode (15) = GPIO.Port_In);
+   GPIO.Configure (16, GPIO.Port_In);
+   pragma Assert (GPIO.Pin_Mode (15) = GPIO.Port_In);
+   pragma Assert (GPIO.Pin_Mode (16) = GPIO.Port_In);
 end Main;

--- a/tests/platform/stm32f0/main.adb
+++ b/tests/platform/stm32f0/main.adb
@@ -1,6 +1,14 @@
+with Componolit.Runtime.Drivers.GPIO;
 
-procedure Main
+procedure Main with
+   SPARK_Mode
 is
+   package GPIO renames Componolit.Runtime.Drivers.GPIO;
+   use type GPIO.Mode;
 begin
-   null;
+   GPIO.Initialize;
+   GPIO.Configure (GPIO.PC8, GPIO.Port_Out);
+   GPIO.Configure (GPIO.PC9, GPIO.Port_Out);
+   pragma Assert (GPIO.Pin_Mode (GPIO.PC8) = GPIO.Port_Out);
+   pragma Assert (GPIO.Pin_Mode (GPIO.PC9) = GPIO.Port_Out);
 end Main;


### PR DESCRIPTION
 - GPIO Pins can only be read or written after they have been configured
 - State differences between different pins are tracked correctly